### PR TITLE
LITTIL-174 GitHub Actions with deprecated commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v5.5
+        uses: tj-actions/branch-names@v6
       - name: Analyze build code
         uses: sonarsource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
In GitHub Actions the following Warning is shown :
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This can be sovled by upgrade of the github action tj-actions/branch-names