### PR TITLE
Externalize identity provider config

### DIFF
--- a/.github/workflows/publish-to-aws.yml
+++ b/.github/workflows/publish-to-aws.yml
@@ -4,7 +4,7 @@ name: publish-to-aws
 on:
   push:
     branches:
-      - LITTIL-95-Front-end-infrastructure
+      - externalize-identity-provider-config
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-aws.yml
+++ b/.github/workflows/publish-to-aws.yml
@@ -4,7 +4,7 @@ name: publish-to-aws
 on:
   push:
     branches:
-      - externalize-identity-provider-config
+      - main
 
 jobs:
   publish:

--- a/.github/workflows/publish-to-aws.yml
+++ b/.github/workflows/publish-to-aws.yml
@@ -50,5 +50,6 @@ jobs:
           aws sts get-caller-identity
       - name: Sync files to S3
         run: |
+          cp src/config.staging.js dist/littil-org-website/config.js
           aws s3 sync --delete dist/littil-org-website/. s3://${{ secrets.AWS_S3_BUCKET }}
           aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,10 @@
 import { CommonModule } from '@angular/common';
-import {
-  HttpClient,
-  HttpClientModule,
-  HTTP_INTERCEPTORS,
-} from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClient, HttpClientModule, } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AuthHttpInterceptor, AuthModule } from '@auth0/auth0-angular';
-import { environment } from '../environments/environment';
+import { getLittilConfigFromWindow } from '../littilConfig';
 import { ApiModule, Configuration } from './api/generated';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -19,12 +15,14 @@ import { MainMenuDropdownButtonModule } from './components/main-menu-dropdown-bu
 import { ModalControllerModule } from './components/modal/modal.controller.module';
 import { RegisterModalModule } from './components/register-modal/register-modal.module';
 
+const littilConfig = getLittilConfigFromWindow();
+
 @NgModule({
   declarations: [AppComponent],
   imports: [
     ApiModule.forRoot(() => {
       return new Configuration({
-        basePath: environment.serverUrl,
+        basePath: littilConfig.apiHost,
       });
     }),
     BrowserModule,
@@ -39,17 +37,17 @@ import { RegisterModalModule } from './components/register-modal/register-modal.
     MainMenuDropdownButtonModule,
     ModalControllerModule.forRoot(),
     AuthModule.forRoot({
-      domain: environment.auth0Domain,
-      clientId: environment.auth0ClientId,
-      audience: environment.auth0Audience,
+      domain: littilConfig.auth0Domain,
+      clientId: littilConfig.auth0ClientId,
+      audience: littilConfig.auth0Audience,
       httpInterceptor: {
         allowedList: [
           {
-            uri: `${environment.serverUrl}/api/v1/users/user`,
+            uri: `${littilConfig.apiHost}/api/v1/users/user`,
             allowAnonymous: true,
           },
           {
-            uri: `${environment.serverUrl}/api/*`,
+            uri: `${littilConfig.apiHost}/api/*`,
           },
         ],
       },
@@ -66,4 +64,5 @@ import { RegisterModalModule } from './components/register-modal/register-modal.
   bootstrap: [AppComponent],
   exports: [],
 })
-export class AppModule {}
+export class AppModule {
+}

--- a/src/app/services/littil-school/littil-school.service.spec.ts
+++ b/src/app/services/littil-school/littil-school.service.spec.ts
@@ -1,16 +1,11 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import {
-  createHttpFactory,
-  HttpMethod,
-  SpectatorHttp,
-} from '@ngneat/spectator';
-import { environment } from '../../../environments/environment';
+import { createHttpFactory, HttpMethod, SpectatorHttp, } from '@ngneat/spectator';
 import { School, SchoolService } from '../../api/generated';
 import { LittilSchoolService } from './littil-school.service';
 
 describe('LittilSchoolService', () => {
-  let baseUrl = environment.serverUrl;
+  let baseUrl = 'http://localhost:8080';
   let service: LittilSchoolService;
   let spectator: SpectatorHttp<LittilSchoolService>;
   const createHttp = createHttpFactory(LittilSchoolService);

--- a/src/app/services/littil-teacher/littil-teacher.service.spec.ts
+++ b/src/app/services/littil-teacher/littil-teacher.service.spec.ts
@@ -1,16 +1,11 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import {
-  createHttpFactory,
-  HttpMethod,
-  SpectatorHttp,
-} from '@ngneat/spectator';
-import { environment } from '../../../environments/environment';
+import { createHttpFactory, HttpMethod, SpectatorHttp, } from '@ngneat/spectator';
 import { GuestTeacherPostResource, TeacherService } from '../../api/generated';
 import { LittilTeacherService } from './littil-teacher.service';
 
 describe('LittilTeacherService', () => {
-  let baseUrl = environment.serverUrl;
+  let baseUrl = 'http://localhost:8080';
   let service: LittilTeacherService;
   let spectator: SpectatorHttp<LittilTeacherService>;
   const createHttp = createHttpFactory(LittilTeacherService);

--- a/src/app/services/littil-user/littil-user.service.spec.ts
+++ b/src/app/services/littil-user/littil-user.service.spec.ts
@@ -1,16 +1,11 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import {
-  createHttpFactory,
-  HttpMethod,
-  SpectatorHttp,
-} from '@ngneat/spectator';
-import { environment } from '../../../environments/environment';
+import { createHttpFactory, HttpMethod, SpectatorHttp, } from '@ngneat/spectator';
 import { User, UsersService } from '../../api/generated';
 import { LittilUserService } from './littil-user.service';
 
 describe('LittilUserService', () => {
-  let baseUrl = environment.serverUrl;
+  let baseUrl = 'http://localhost:8080';
   let service: LittilUserService;
   let spectator: SpectatorHttp<LittilUserService>;
   const createHttp = createHttpFactory(LittilUserService);

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,3 @@
-var littilConfig = {
+const littilConfig = {
   apiHost: 'http://localhost:8080',
 };

--- a/src/config.production.js
+++ b/src/config.production.js
@@ -1,0 +1,6 @@
+const littilConfig = {
+  apiHost: 'https://api.littil.org',
+  auth0Domain: '',
+  auth0ClientId: '',
+  auth0Audience: '',
+};

--- a/src/config.staging.js
+++ b/src/config.staging.js
@@ -1,0 +1,6 @@
+const littilConfig = {
+  apiHost: 'https://api.staging.littil.org',
+  auth0Domain: 'staging-littil.eu.auth0.com',
+  auth0ClientId: 'EffRlk5Kg5p1j3yu0WAeZrhwRKDCZGDJ',
+  auth0Audience: 'littil-backend',
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,3 @@
 export const environment = {
   production: true,
-  auth0Domain: '',
-  auth0ClientId: '',
-  auth0Audience: '',
-  serverUrl: '',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,10 +4,6 @@
 
 export const environment = {
   production: false,
-  auth0Domain: 'dev-g60bne29.eu.auth0.com',
-  auth0ClientId: '1MWGJlOHqjqNHiPZKEY5R4C7fsQySr9k',
-  auth0Audience: 'littil-backend',
-  serverUrl: 'http://localhost:8080',
 };
 
 /*

--- a/src/littilConfig.ts
+++ b/src/littilConfig.ts
@@ -4,7 +4,21 @@ export const LITTILCONFIG: InjectionToken<LittilConfig> = new InjectionToken('Li
 
 export interface LittilConfig {
   apiHost: string;
+  auth0Domain: string;
+  auth0ClientId: string;
+  auth0Audience: string;
 }
 
 export const isLittilConfig = (input: unknown): input is LittilConfig =>
-  typeof (input as LittilConfig)?.apiHost === 'string';
+  typeof (input as LittilConfig)?.apiHost === 'string'
+  && typeof (input as LittilConfig)?.auth0Domain === 'string'
+  && typeof (input as LittilConfig)?.auth0ClientId === 'string'
+  && typeof (input as LittilConfig)?.auth0Audience === 'string';
+
+export const getLittilConfigFromWindow = (): LittilConfig => {
+  const externalConfig = (window as any).littilConfig;
+  if (!isLittilConfig(externalConfig)) {
+    throw new Error('No valid external config found; ' + JSON.stringify(externalConfig));
+  }
+  return externalConfig;
+};

--- a/src/littilConfigProviders.ts
+++ b/src/littilConfigProviders.ts
@@ -1,22 +1,18 @@
 import { StaticProvider } from '@angular/core';
 import { BASE_PATH } from './app/api/generated';
-import { isLittilConfig, LITTILCONFIG } from './littilConfig';
+import { getLittilConfigFromWindow, LITTILCONFIG } from './littilConfig';
 
 export const getLittilConfigProviders = (): StaticProvider[] => {
-  const externalConfig = (window as any).littilConfig;
-  if (!isLittilConfig(externalConfig)) {
-    console.warn('No valid external config found; ' + JSON.stringify(externalConfig));
-    return [];
-  }
+  const config = getLittilConfigFromWindow();
 
   return [
     {
       provide: LITTILCONFIG,
-      useValue: externalConfig,
+      useValue: config,
     },
     {
       provide: BASE_PATH,
-      useValue: externalConfig.apiHost,
+      useValue: config.apiHost,
     },
   ];
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic(getLittilConfigProviders())
+platformBrowserDynamic([
+  ...getLittilConfigProviders(),
+])
   .bootstrapModule(AppModule)
   .catch(err => console.error(err));


### PR DESCRIPTION
Replace compile-time configuration (environment.ts) with runtime configuration (external config.js available alongside index.html and other assets). Also replace dev configuration with staging in pipeline (pipeline is not yet parameterized to switch between staging and production).