### PR TITLE
External config fixes for environments

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,7 +64,10 @@
               "vendorChunk": true,
               "extractLicenses": false,
               "sourceMap": true,
-              "namedChunks": true
+              "namedChunks": true,
+              "assets": [
+                "src/config.js"
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,6 @@
-const littilConfig = {
+var littilConfig = {
   apiHost: 'http://localhost:8080',
+  auth0Domain: '',
+  auth0ClientId: '',
+  auth0Audience: '',
 };

--- a/src/config.production.js
+++ b/src/config.production.js
@@ -1,4 +1,4 @@
-const littilConfig = {
+var littilConfig = {
   apiHost: 'https://api.littil.org',
   auth0Domain: '',
   auth0ClientId: '',

--- a/src/config.staging.js
+++ b/src/config.staging.js
@@ -1,4 +1,4 @@
-const littilConfig = {
+var littilConfig = {
   apiHost: 'https://api.staging.littil.org',
   auth0Domain: 'staging-littil.eu.auth0.com',
   auth0ClientId: 'EffRlk5Kg5p1j3yu0WAeZrhwRKDCZGDJ',


### PR DESCRIPTION
Replaced `const` with `var` so that the config variable is compatible and in the correct scope (`window.littilConfig`). Also added the config file as an asset to be able to run locally with dev config.