### PR TITLE
Solve issue deprecated set-output in GitHub Action

### DIFF
--- a/.github/workflows/publish-to-aws.yml
+++ b/.github/workflows/publish-to-aws.yml
@@ -40,7 +40,7 @@ jobs:
             -Dsonar.tests=src/app
             -Dsonar.test.inclusions=**/*.spec.ts
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: github_publish_littil_frontend


### PR DESCRIPTION
aws-actions/configure-aws-credentials@v1 deprecated message :

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
