### PR TITLE
LITTIL-177 Add general HttpInterceptor

### DIFF
--- a/src/app/api/_mock_/__mockhandlers__/mock.handler.ts
+++ b/src/app/api/_mock_/__mockhandlers__/mock.handler.ts
@@ -35,6 +35,16 @@ export class MockHandlers {
     );
   }
 
+  public response503(
+    res: ResponseFunction,
+    ctx: RestContext
+  ): MockedResponse<any> | Promise<MockedResponse<any>> {
+    return res(
+      ctx.status(503),
+      ctx.json({ errorMessage: `Request not available.` })
+    );
+  }
+
   public response200(
     res: ResponseFunction,
     ctx: RestContext,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,25 +1,23 @@
 import { CommonModule } from '@angular/common';
-import {
-  HTTP_INTERCEPTORS,
-  HttpClient,
-  HttpClientModule,
-} from '@angular/common/http';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { GoogleMapsModule } from '@angular/google-maps';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { AuthHttpInterceptor, AuthModule } from '@auth0/auth0-angular';
+import { AuthModule } from '@auth0/auth0-angular';
 import { getLittilConfigFromWindow } from '../littilConfig';
 import { ApiModule, Configuration } from './api/generated';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ButtonModule } from './components/button/button.module';
-import { UserMenuModule } from "./components/user-menu/user-menu.module";
 import { ContentContainerModule } from './components/content-container/content-container.module';
+import { ErrorModalModule } from './components/error-modal/error-modal.module';
 import { MainMenuButtonModule } from './components/main-menu-button/main-menu-button.module';
 import { MainMenuDropdownButtonModule } from './components/main-menu-dropdown-button/main-menu-dropdown-button.module';
 import { ModalControllerModule } from './components/modal/modal.controller.module';
 import { RegisterModalModule } from './components/register-modal/register-modal.module';
-import { GoogleMapsModule } from '@angular/google-maps';
+import { UserMenuModule } from './components/user-menu/user-menu.module';
+import { interceptorProviders } from './interceptors/http-interceptors';
 
 const littilConfig = getLittilConfigFromWindow();
 
@@ -40,6 +38,7 @@ const littilConfig = getLittilConfigFromWindow();
     ButtonModule,
     UserMenuModule,
     RegisterModalModule,
+    ErrorModalModule,
     MainMenuButtonModule,
     MainMenuDropdownButtonModule,
     GoogleMapsModule,
@@ -61,14 +60,7 @@ const littilConfig = getLittilConfigFromWindow();
       },
     }),
   ],
-  providers: [
-    HttpClient,
-    {
-      provide: HTTP_INTERCEPTORS,
-      useClass: AuthHttpInterceptor,
-      multi: true,
-    },
-  ],
+  providers: [HttpClient, interceptorProviders],
   bootstrap: [AppComponent],
   exports: [],
 })

--- a/src/app/components/error-modal/error-modal.component.html
+++ b/src/app/components/error-modal/error-modal.component.html
@@ -1,0 +1,5 @@
+<div [@hideShow]="loading ? 'hidden' : 'visible'" class="prose">
+  <h1 class="font-bold text-lg text-blue-200 mb-3">Oeps, er ging iets mis</h1>
+  <p>Ververs de pagina en probeer het opnieuw.</p>
+  <littil-button [inline]="true" (click)="closeModal()">OK</littil-button>
+</div>

--- a/src/app/components/error-modal/error-modal.component.spec.ts
+++ b/src/app/components/error-modal/error-modal.component.spec.ts
@@ -1,0 +1,58 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import { ErrorModalComponent } from './error-modal.component';
+
+describe('ErrorModalComponent', () => {
+  let spectator: Spectator<ErrorModalComponent>;
+  let component: ErrorModalComponent;
+
+  let closeModalSpy: jest.SpyInstance;
+  let closeSpy: jest.SpyInstance;
+
+  const createComponent = createComponentFactory({
+    component: ErrorModalComponent,
+    declarations: [],
+    imports: [NoopAnimationsModule],
+    providers: [],
+    mocks: [],
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, ReactiveFormsModule, FormsModule],
+    });
+    spectator = createComponent();
+    spectator.component.close = () => true;
+    spectator.detectChanges();
+    component = spectator.component;
+    closeModalSpy = jest.spyOn(component, 'closeModal');
+    closeSpy = jest.spyOn(component, 'close');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('closeModal', () => {
+    it('should close modal when clicked on cancel', async () => {
+      component.closeModal();
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Template', () => {
+    it('should show error text', () => {
+      expect(spectator.query('h1')).toBeDefined();
+      expect(spectator.query('h1')?.textContent).toEqual(
+        'Oeps, er ging iets mis'
+      );
+      expect(spectator.query('p')).toBeDefined();
+      expect(spectator.query('p')?.textContent).toEqual(
+        'Ververs de pagina en probeer het opnieuw.'
+      );
+    });
+  });
+});

--- a/src/app/components/error-modal/error-modal.component.ts
+++ b/src/app/components/error-modal/error-modal.component.ts
@@ -1,0 +1,49 @@
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+import { Component } from '@angular/core';
+import { IModalComponent } from '../modal/modal.controller';
+
+@Component({
+  selector: 'littil-error-modal',
+  templateUrl: 'error-modal.component.html',
+  animations: [
+    trigger('hideShow', [
+      state(
+        'hidden',
+        style({
+          opacity: 0,
+        })
+      ),
+      state(
+        'visible',
+        style({
+          opacity: 1,
+        })
+      ),
+      transition('hidden => visible', [animate('200ms')]),
+    ]),
+  ],
+})
+export class ErrorModalComponent
+  implements IModalComponent<undefined, IErrorModalInput>
+{
+  public loading = false;
+  public message = '';
+  close!: () => void;
+
+  public onOpen(errorData: IErrorModalInput) {}
+
+  public closeModal() {
+    this.close();
+  }
+}
+
+export interface IErrorModalInput {
+  errorMessage: string;
+  errorStatus: number;
+}

--- a/src/app/components/error-modal/error-modal.module.ts
+++ b/src/app/components/error-modal/error-modal.module.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
+import { ErrorModalComponent } from './error-modal.component';
+import { ButtonModule } from '../button/button.module';
+
+@NgModule({
+  declarations: [ErrorModalComponent],
+  imports: [CommonModule, MatDialogModule, ButtonModule],
+  exports: [ErrorModalComponent],
+  entryComponents: [ErrorModalComponent],
+})
+export class ErrorModalModule {}

--- a/src/app/components/modal/modal.controller.ts
+++ b/src/app/components/modal/modal.controller.ts
@@ -27,7 +27,7 @@ export class ModalController {
       dialogConfig.closeOnNavigation = options && !options.disableClose;
       dialogConfig.disableClose = true;
       dialogConfig.minWidth = '20%';
-      dialogConfig.minHeight = '50vh';
+      // dialogConfig.minHeight = '50vh';
       if (options && options.modalSize) {
         switch (options.modalSize) {
           case ModalSize.SM:

--- a/src/app/interceptors/error-interceptor.service.ts
+++ b/src/app/interceptors/error-interceptor.service.ts
@@ -1,0 +1,48 @@
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+import {
+  ErrorModalComponent,
+  IErrorModalInput,
+} from '../components/error-modal/error-modal.component';
+import {
+  ModalController,
+  ModalSize,
+} from '../components/modal/modal.controller';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorInterceptorService implements HttpInterceptor {
+  constructor(private modalController: ModalController) {}
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      tap(
+        null,
+        (error) => {
+          if (error instanceof HttpErrorResponse) {
+            this.modalController.present(
+              ErrorModalComponent,
+              {
+                errorMessage: error.message,
+                errorStatus: error.status,
+              } as IErrorModalInput,
+              { modalSize: ModalSize.SM }
+            );
+          }
+          return error;
+        },
+        null
+      )
+    );
+  }
+}

--- a/src/app/interceptors/http-interceptors.ts
+++ b/src/app/interceptors/http-interceptors.ts
@@ -1,0 +1,16 @@
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { AuthHttpInterceptor } from '@auth0/auth0-angular';
+import { ErrorInterceptorService } from './error-interceptor.service';
+
+export const interceptorProviders = [
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: AuthHttpInterceptor,
+    multi: true,
+  },
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: ErrorInterceptorService,
+    multi: true,
+  },
+];


### PR DESCRIPTION
- Show an error message modal popup when BE calls return error
- We can specify this for 404, 503 errors etc
- We can also make these messages very specific per api endpoint (for example: message for a failing school PUT: "We could not save the changes" etc