### PR TITLE
LITTIL-244 change hardcoded link to routerLink

### DIFF
--- a/src/app/components/contact-banner/contact-banner.component.html
+++ b/src/app/components/contact-banner/contact-banner.component.html
@@ -1,7 +1,7 @@
 <p class="font-bold text-3xl">
   <span class="prefix">{{ prefixText }}</span>
   <a class="text-blue-200 hover:text-blue-100 cursor-pointer font-bold"
-    href="https://www.littil.org/contact/" target="_blank">
+    [routerLink]="'/contact'">
     {{ linkText }}
   </a>
   <span class="suffix">{{ suffixText }}</span>

--- a/src/app/components/contact-banner/contact-banner.module.ts
+++ b/src/app/components/contact-banner/contact-banner.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {ContactBannerComponent} from "./contact-banner.component";
+import { ContactBannerComponent } from './contact-banner.component';
+import { RouterLinkWithHref } from '@angular/router';
 
 @NgModule({
   declarations: [
@@ -10,7 +11,8 @@ import {ContactBannerComponent} from "./contact-banner.component";
     ContactBannerComponent
   ],
   imports: [
-    CommonModule
+    CommonModule,
+    RouterLinkWithHref
   ]
 })
 export class ContactBannerModule { }


### PR DESCRIPTION
The hardcoded link to external website https://www.littil.org/contact/ is changed to routerLink /contact