### PR TITLE
LITTIL-254 don't show error message in advance

### DIFF
--- a/src/app/components/register-modal/register-modal.component.html
+++ b/src/app/components/register-modal/register-modal.component.html
@@ -17,29 +17,32 @@
         label="E-mailadres"
         [hasError]="FormUtil.InValid(registerForm.controls['email'])"
       >
-        <littil-form-error-message
-          [errorText]="FormUtil.ContainsError(registerForm.controls['email'], 'required') ? 'E-mailadres is verplicht' : (FormUtil.ContainsError(registerForm.controls['email'], 'email') ? 'Vul een geldig e-mailadres in' : '&nbsp;')"
-        ></littil-form-error-message>
       </littil-form-input-text>
     </form>
 
-    <littil-button-rounded
-      data-test="registerButton"
-      [inline]="true"
-      [disabled]="creatingProfile"
-      (click)="onClickRegister()"
-      >Registreren</littil-button-rounded
-    >
-    <littil-button-rounded
-      data-test="cancelButton"
-      [inline]="true"
-      [disabled]="creatingProfile"
-      [color]="'yellow'"
-      (click)="closeModal()"
-      >Annuleren</littil-button-rounded
-    >
+    <div class="flex">
+      <littil-button-rounded
+        data-test="registerButton"
+        [inline]="true"
+        [disabled]="creatingProfile"
+        (click)="onClickRegister()"
+        >Registreren</littil-button-rounded
+      >
+      <littil-button-rounded
+        data-test="cancelButton"
+        [inline]="true"
+        [disabled]="creatingProfile"
+        [color]="'yellow'"
+        (click)="closeModal()"
+        class="mr-4"
+        >Annuleren</littil-button-rounded
+      >
+      <littil-form-error-message *ngIf="registerForm.controls['email'].dirty || registerForm.controls['email'].touched"
+          [errorText]="FormUtil.ContainsError(registerForm.controls['email'], 'required') ? 'E-mailadres is verplicht' : (FormUtil.ContainsError(registerForm.controls['email'], 'email') ? 'Vul een geldig e-mailadres in' : '')"
+      ></littil-form-error-message>
+    </div>
+    <p *ngIf="creatingProfile">Uw account wordt aangemaakt</p>
   </ng-container>
-  <p *ngIf="creatingProfile">Uw account wordt aangemaakt</p>
 </div>
 
 <div [@hideShow]="hideConfirmation ? 'hidden' : 'visible'" class="prose">


### PR DESCRIPTION
Hide error message when the register form is opened.

**Register form when opened**
![image](https://github.com/Devoxx4Kids-NPO/littil-frontend/assets/98379322/798ec6ed-a492-42de-ad87-d3040b23607d)

**Register form with error message*
![image](https://github.com/Devoxx4Kids-NPO/littil-frontend/assets/98379322/46ad7818-94f8-46f8-b0e8-40e7cb17cec9)
