### PR TITLE
LITTIL-252 same look and feel for profile and modules

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1539,6 +1539,176 @@
           "Auth0" : [ "admin" ]
         } ]
       }
+    },
+    "/api/v2/guest-teachers/{id}/modules" : {
+      "get" : {
+        "tags" : [ "Teacher Modules" ],
+        "summary" : "Fetch the list of modules for a specific guestTeacher",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Modules for guestTeacher with Id found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Module"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "GuestTeacher with specific Id was not found."
+          },
+          "401" : {
+            "description" : "Current user is not owner of this guestTeacher"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Teacher Modules" ],
+        "summary" : "Update the list of modules for a specific guestTeacher",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Successfully updated the modules for the given guestTeacher.",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "404" : {
+            "description" : "The guestTeacher or one of the modules was not found."
+          },
+          "401" : {
+            "description" : "Current user is not owner of this guestTeacher"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/schools/{id}/modules" : {
+      "get" : {
+        "tags" : [ "School Modules" ],
+        "summary" : "Fetch the list of modules for a specific school",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Modules for school with Id found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Module"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "School with specific Id was not found."
+          },
+          "401" : {
+            "description" : "Current user is not owner of this school"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "School Modules" ],
+        "summary" : "Update the list of modules for a specific school",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Successfully updated the modules for the given school.",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "404" : {
+            "description" : "The school or one of the modules was not found."
+          },
+          "401" : {
+            "description" : "Current user is not owner of this school"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
     }
   },
   "components" : {

--- a/src/app/pages/admin/modules/modules.component.html
+++ b/src/app/pages/admin/modules/modules.component.html
@@ -1,4 +1,5 @@
 <littil-profile-container title="Modules wijzigen">
+
   <fieldset class="not-prose">
     <legend class="sr-only">Modules</legend>
     <div data-test="module-list">
@@ -6,11 +7,9 @@
         <div class="flex h-6 items-center">
           <input [id]="availableModule.id"
                  [name]="availableModule.id"
-                 (change)="saveModuleStatus(availableModule)"
-                 [checked]="isModuleUsedByUser(availableModule)"
-                 [disabled]="isModuleBeingSaved(availableModule)"
-                 [ngClass]="isModuleBeingSaved(availableModule)
-                 ? 'text-gray-200 focus:ring-gray-200' : 'text-green-700 focus:ring-green-700'"
+                 (change)="updateSelectedModules(availableModule)"
+                 [checked]="isSelectedModule(availableModule)"
+                 [ngClass]="'text-blue-200 focus:ring-blue-200'"
                  aria-describedby="comments-description" type="checkbox" class="h-4 w-4 rounded border-gray-300">
         </div>
         <div class="ml-3 text-sm leading-6">
@@ -19,5 +18,12 @@
       </div>
     </div>
   </fieldset>
+
+  <div class="flex flex-row gap-4 justify-between mt-4">
+    <div>
+      <littil-button-rounded data-test="saveButton" [inline]="true" (click)="onClickSaveModules()">Modules opslaan</littil-button-rounded>
+      <littil-button-rounded data-test="cancelButton" [inline]="true" (click)="onClickCancelChanges()" color="yellow">Wijzigingen annuleren</littil-button-rounded>
+    </div>
+  </div>
 </littil-profile-container>
 <littil-footer></littil-footer>

--- a/src/app/pages/admin/modules/modules.component.spec.ts
+++ b/src/app/pages/admin/modules/modules.component.spec.ts
@@ -12,7 +12,6 @@ import { ProfileContainerComponent } from "../../../components/profile-container
 import { DebugElement, NO_ERRORS_SCHEMA } from "@angular/core";
 import { By } from "@angular/platform-browser";
 
-
 const availableModules: Module[] = [
   {"id": "31000000-0000-0000-0000-000000000000", "name": "CodeCombat"},
   {"id": "35000000-0000-0000-0000-000000000000", "name": "Hedycode"},
@@ -31,31 +30,34 @@ const schoolModules: Module[] = [
 ];
 
 
+function getModuleDef() {
+  return {
+    declarations: [ModulesComponent, ProfileContainerComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      MockProvider(PermissionController, {
+        getRoleType: () => Roles.GuestTeacher,
+      }),
+      MockProvider(LittilModulesService, {
+        getAll: () => of(availableModules),
+      }),
+      MockProvider(LittilTeacherService, {
+        getModules: () => of(teacherModules),
+        addModules: () => of(true),
+      }),
+      MockProvider(LittilSchoolService, {
+        getModules: () => of(schoolModules),
+      }),
+    ]
+  };
+}
+
 describe('Teacher Modules Component', () => {
   let component: ModulesComponent;
   let fixture: ComponentFixture<ModulesComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ ModulesComponent, ProfileContainerComponent ],
-      schemas: [ NO_ERRORS_SCHEMA ],
-      providers: [
-        MockProvider(PermissionController, {
-          getRoleType: () => Roles.GuestTeacher,
-        }),
-        MockProvider(LittilModulesService, {
-          getAll: () => of(availableModules),
-        }),
-        MockProvider(LittilTeacherService, {
-          getModules: () => of(teacherModules),
-          addModule: () => of(true),
-          removeModule: () => of(true),
-        }),
-        MockProvider(LittilSchoolService, {
-          getModules: () => of(schoolModules),
-        }),
-      ]
-    })
+    await TestBed.configureTestingModule(getModuleDef())
                  .compileComponents();
 
     fixture = TestBed.createComponent(ModulesComponent);
@@ -88,9 +90,8 @@ describe('Teacher Modules Component', () => {
 
     checkbox.nativeElement.click();
     expect(checkbox.nativeElement.checked).toBe(true);
-    expect(component.userModules.find(m => m.id === availableModules[1].id)).toBeTruthy();
-
-    expect(component.isModuleBeingSaved(availableModules[1])).toBeFalsy();
+    expect(component.selectedModules.find(moduleId => moduleId === availableModules[1].id)).toBeTruthy();
+    expect(component.selectedModules.length).toEqual(component.userModules.length + 1)
   });
 
   it('can be clicked to remove a module', () => {
@@ -102,7 +103,32 @@ describe('Teacher Modules Component', () => {
 
     checkbox.nativeElement.click();
     expect(checkbox.nativeElement.checked).toBeFalsy();
-    expect(component.userModules.find(m => m.id === availableModules[0].id)).toBeFalsy();
-    expect(component.isModuleBeingSaved(availableModules[0])).toBeFalsy();
+    expect(component.selectedModules.find(moduleId => moduleId === availableModules[0].id)).toBeFalsy();
+    expect(component.selectedModules.length).toEqual(component.userModules.length - 1)
   });
+
+  it('should call save moduiles function when clicked on save button', async () => {
+    const debug: DebugElement = fixture.debugElement;
+    const saveBtn: DebugElement = debug.query(By.css(`[data-test="saveButton"]`));
+
+    expect(saveBtn).toBeDefined();
+    component.selectedModules.push(component.availableModules[2].id as string);
+    expect(component.selectedModules.length).toEqual(component.userModules.length + 1)
+
+    saveBtn.nativeElement.click();
+    expect(component.selectedModules.length).toEqual(component.userModules.length)
+  });
+
+  it('should cancel updates of selected modules when clicked on cancel button', async () => {
+    const debug: DebugElement = fixture.debugElement;
+    const cancelBtn: DebugElement = debug.query(By.css(`[data-test="cancelButton"]`));
+
+    expect(cancelBtn).toBeDefined();
+    component.selectedModules.push(component.availableModules[2].id as string);
+    expect(component.selectedModules.length).toEqual(component.userModules.length + 1)
+
+    cancelBtn.nativeElement.click();
+    expect(component.selectedModules.length).toEqual(component.userModules.length)
+  });
+
 });

--- a/src/app/pages/admin/modules/modules.component.ts
+++ b/src/app/pages/admin/modules/modules.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component } from "@angular/core";
 import { Module } from "../../../api/generated";
 import { LittilModulesService } from "../../../services/littil-modules/littil-modules.service";
 import { LittilTeacherService } from "../../../services/littil-teacher/littil-teacher.service";
@@ -17,7 +17,7 @@ export class ModulesComponent {
   private readonly roleId: string;
   public availableModules: Module[] = [];
   public userModules: Module[] = [];
-  public modulesSaving: string[] = [];
+  public selectedModules: string[] = [];
   private userModuleManager: IHasManageableModules;
 
   constructor(
@@ -29,46 +29,48 @@ export class ModulesComponent {
     this.roleType = this.permissionController.getRoleType();
     this.roleId = this.permissionController.getRoleId();
     this.userModuleManager = this.roleType == Roles.GuestTeacher ? littilTeacherService : littilSchoolService;
-
     forkJoin([
       this.littilModulesService.getAll(),
-      this.userModuleManager.getModules(this.roleId)
-    ]).pipe(
+      this.userModuleManager.getModules(this.roleId),
+
+  ]).pipe(
       map(([ availableModules, userModules ]) => {
         this.availableModules = availableModules;
         this.userModules = userModules;
+        this.selectedModules = userModules.map(m => m.id as string)
       })
     ).subscribe();
   }
 
-  isModuleUsedByUser(module: Module): boolean {
-    return this.userModules.filter(m => m.id === module.id).length > 0;
+  isSelectedModule(module: Module): boolean {
+    return this.selectedModules.filter(id => id === module.id).length > 0;
   }
 
-  isModuleBeingSaved(module: Module): boolean {
-    return this.modulesSaving.includes((module.id as string));
-  }
-
-  removeModuleFromSaving(moduleId: string): void {
-    this.modulesSaving = this.modulesSaving.filter(m => moduleId !== m);
-  }
-
-  saveModuleStatus(module: Module): void {
+  updateSelectedModules(module: Module): void {
     const moduleId = module.id as string;
 
-    if (!this.modulesSaving.includes(moduleId)) {
-      this.modulesSaving.push(moduleId);
-      if (this.isModuleUsedByUser(module)) {
-        this.userModuleManager.removeModule(this.roleId, moduleId).subscribe(() => {
-          this.removeModuleFromSaving(moduleId);
-          this.userModules = this.userModules.filter(m => moduleId !== m.id);
-        });
-      } else {
-        this.userModuleManager.addModule(this.roleId, module).subscribe(() => {
-          this.removeModuleFromSaving(moduleId);
-          this.userModules.push(module);
-        });
-      }
+    if (!this.selectedModules.includes(moduleId)) {
+      this.selectedModules.push(moduleId);
+    } else {
+      this.removeModuleFromSelectedModules(moduleId);
     }
+  }
+
+  removeModuleFromSelectedModules(moduleId: string): void {
+    this.selectedModules = this.selectedModules.filter(m => moduleId !== m);
+  }
+
+  onClickSaveModules() : void {
+    this.userModuleManager
+      .addModules(this.roleId, this.selectedModules)
+      .subscribe(() => {
+        this.userModules = this.availableModules
+          .filter(m => this.selectedModules.includes(m.id as string));
+      });
+  }
+
+  onClickCancelChanges():  void {
+    this.selectedModules = this.userModules
+      .map(m => m.id as string);
   }
 }

--- a/src/app/pages/admin/modules/modules.module.ts
+++ b/src/app/pages/admin/modules/modules.module.ts
@@ -2,9 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FooterModule } from '../../../components/footer/footer.module';
 import { ModulesComponent } from './modules.component';
-import { RouterModule, Routes } from "@angular/router";
-import { ProfileContainerModule } from "../../../components/profile-container/profile-container.module";
-import { ReactiveFormsModule } from "@angular/forms";
+import { RouterModule, Routes } from '@angular/router';
+import { ProfileContainerModule } from '../../../components/profile-container/profile-container.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ButtonModule } from '../../../components/button/button.module';
 
 const routes: Routes = [
   {
@@ -23,6 +24,7 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     ReactiveFormsModule,
     FooterModule,
+    ButtonModule,
   ],
   exports: [
     ModulesComponent

--- a/src/app/services/littil-modules/littil-modules-user.interface.ts
+++ b/src/app/services/littil-modules/littil-modules-user.interface.ts
@@ -3,6 +3,5 @@ import { Module } from "../../api/generated";
 
 export interface IHasManageableModules {
   getModules: (id: string) => Observable<Module[]>;
-  addModule: (id: string, module: Module) => Observable<any>;
-  removeModule: (id: string, moduleId: string) => Observable<any>;
+  addModules: (id: string, modules: string[]) => Observable<any>;
 }

--- a/src/app/services/littil-school/littil-school.service.spec.ts
+++ b/src/app/services/littil-school/littil-school.service.spec.ts
@@ -65,18 +65,11 @@ describe('LittilSchoolService', () => {
   describe('modules', () => {
     it('should get modules for school', () => {
       spectator.service.getModules('123').subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/schools/123/modules', HttpMethod.GET);
+      spectator.expectOne(baseUrl + '/api/v2/schools/123/modules', HttpMethod.GET);
     });
-    it('should add a module for a school', () => {
-      spectator.service.addModule('123', {
-        id: "test",
-        name: "name"
-      }).subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/schools/123/modules', HttpMethod.POST);
-    });
-    it('should delete a module for a school', () => {
-      spectator.service.removeModule('123', '567').subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/schools/123/modules/567', HttpMethod.DELETE);
+    it('should update the modules for a school', () => {
+      spectator.service.addModules('123', [ "456"] ).subscribe();
+      spectator.expectOne(baseUrl + '/api/v2/schools/123/modules', HttpMethod.POST);
     });
   });
 });

--- a/src/app/services/littil-school/littil-school.service.ts
+++ b/src/app/services/littil-school/littil-school.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   ApiV1SchoolsGet200Response,
-  Module,
   School,
   SchoolModulesService,
   SchoolPostResource,
@@ -43,14 +42,11 @@ export class LittilSchoolService implements IHasManageableModules {
   }
 
   getModules(id: string): Observable<any> {
-    return this.schoolModulesService.apiV1SchoolsIdModulesGet(id);
+    return this.schoolModulesService.apiV2SchoolsIdModulesGet(id);
   }
 
-  addModule(schoolId: string, module: Module): Observable<any> {
-    return this.schoolModulesService.apiV1SchoolsIdModulesPost(schoolId, module);
+  addModules(schoolId: string, modules: string[]): Observable<any> {
+    return this.schoolModulesService.apiV2SchoolsIdModulesPost(schoolId, modules);
   }
 
-  removeModule(schoolId: string, moduleId: string): Observable<any> {
-    return this.schoolModulesService.apiV1SchoolsIdModulesModuleIdDelete(schoolId, moduleId);
-  }
 }

--- a/src/app/services/littil-teacher/littil-teacher.service.spec.ts
+++ b/src/app/services/littil-teacher/littil-teacher.service.spec.ts
@@ -69,20 +69,11 @@ describe('LittilTeacherService', () => {
   describe('modules', () => {
     it('should get modules for teacher', () => {
       spectator.service.getModules('123').subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/guest-teachers/123/modules', HttpMethod.GET);
+      spectator.expectOne(baseUrl + '/api/v2/guest-teachers/123/modules', HttpMethod.GET);
     });
-    it('should add a module for a teacher', () => {
-      spectator.service.addModule('123', {
-        id: "test",
-        name: "name"
-      }).subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/guest-teachers/123/modules', HttpMethod.POST);
-    });
-    it('should delete a module for a teacher', () => {
-      spectator.service.removeModule('123', '567').subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/guest-teachers/123/modules/567', HttpMethod.DELETE);
+    it('should update the modules for a teacher', () => {
+      spectator.service.addModules('123', [ "456" ] ).subscribe();
+      spectator.expectOne(baseUrl + '/api/v2/guest-teachers/123/modules', HttpMethod.POST);
     });
   });
-  // http://localhost:8080/api/v1/guest-teachers/123/modules/567
-  // http://localhost:8080/api/v1/guest-teachers/567/modules/12
 });

--- a/src/app/services/littil-teacher/littil-teacher.service.ts
+++ b/src/app/services/littil-teacher/littil-teacher.service.ts
@@ -39,15 +39,11 @@ export class LittilTeacherService implements IHasManageableModules {
   }
 
   getModules(id: string): Observable<Module[]> {
-    return this.teacherModulesService.apiV1GuestTeachersIdModulesGet(id);
+    return this.teacherModulesService.apiV2GuestTeachersIdModulesGet(id);
   }
 
-  addModule(teacherId: string, module: Module): Observable<any> {
-    return this.teacherModulesService.apiV1GuestTeachersIdModulesPost(teacherId, module);
-  }
-
-  removeModule(teacherId: string, moduleId: string): Observable<any> {
-    return this.teacherModulesService.apiV1GuestTeachersIdModulesModuleIdDelete(teacherId, moduleId);
+  addModules(teacherId: string, modules: string[]): Observable<any> {
+    return this.teacherModulesService.apiV2GuestTeachersIdModulesPost(teacherId, modules);
   }
 
 }


### PR DESCRIPTION
Create same look and feel in profiles and modules screen.
Added save and cancel buttons to modules screen.

There is a dependeny with the following PR from the backend [LITTIL-265 new endpoint(s) for guestTeacher/school modules #263](https://github.com/Devoxx4Kids-NPO/littil-backend/pull/263)


Before : 
![image](https://github.com/Devoxx4Kids-NPO/littil-frontend/assets/98379322/f4109012-bc8b-46f4-a0c0-96dbcf1908c5)

After:
![image](https://github.com/Devoxx4Kids-NPO/littil-frontend/assets/98379322/f90766b0-bf49-4b4c-ab4a-a6496db4e0f7)

