### PR TITLE
Force user to complete profile on first time login

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -37,6 +37,7 @@ const routes: Routes = [
     path: '',
     loadChildren: () =>
       import('./pages/website/website.module').then((m) => m.WebsiteModule),
+    canActivate: [CompleteProfileGuardService],
     resolve: {
       auth: AuthenticatorResolver,
     },


### PR DESCRIPTION
Deze wijziging zorgt ervoor dat een gebruiker na inloggen gevraagd wordt om zijn/haar profiel compleet te maken (net zo lang tot dat is gedaan). Hierdoor weten we of gebruiker een docent of IT'er is en waar hij/zij woont.