### PR TITLE
remove completeProfileGuard for loading pages

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -37,7 +37,6 @@ const routes: Routes = [
     path: '',
     loadChildren: () =>
       import('./pages/website/website.module').then((m) => m.WebsiteModule),
-    canActivate: [CompleteProfileGuardService],
     resolve: {
       auth: AuthenticatorResolver,
     },


### PR DESCRIPTION
completeProfileGuard is causing issue with loading the static pages. The are only visible after logging in.