### PR TITLE
update user profile menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v6
       - name: Analyze build code
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish-to-aws.yml
+++ b/.github/workflows/publish-to-aws.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Analyze build code
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/openapi.json
+++ b/openapi.json
@@ -45,6 +45,20 @@
   } ],
   "components" : {
     "schemas" : {
+      "ChangeEmailResource" : {
+        "required" : [ "newEmailAddress", "verificationCode" ],
+        "type" : "object",
+        "properties" : {
+          "newEmailAddress" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "verificationCode" : {
+            "minLength" : 1,
+            "type" : "string"
+          }
+        }
+      },
       "ContactPostResource" : {
         "required" : [ "recipient", "medium", "message" ],
         "type" : "object",
@@ -85,6 +99,16 @@
       "DayOfWeek" : {
         "enum" : [ "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY" ],
         "type" : "string"
+      },
+      "EmailVerficationCodeResource" : {
+        "required" : [ "emailAddress" ],
+        "type" : "object",
+        "properties" : {
+          "emailAddress" : {
+            "minLength" : 1,
+            "type" : "string"
+          }
+        }
       },
       "ErrorMessage" : {
         "type" : "object",
@@ -1423,6 +1447,7 @@
     "/api/v1/users/statistics" : {
       "get" : {
         "summary" : "Get statistics of users",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "responses" : {
           "200" : {
@@ -1446,13 +1471,14 @@
           }
         },
         "security" : [ {
-          "Auth0" : [ "admin" ]
+          "Auth0" : [ ]
         } ]
       }
     },
     "/api/v1/users/user" : {
       "get" : {
         "summary" : "Get all users",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "responses" : {
           "200" : {
@@ -1476,11 +1502,12 @@
           }
         },
         "security" : [ {
-          "Auth0" : [ "admin" ]
+          "Auth0" : [ ]
         } ]
       },
       "post" : {
         "summary" : "Create a new user",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "requestBody" : {
           "content" : {
@@ -1581,6 +1608,7 @@
     "/api/v1/users/user/provider/{id}" : {
       "get" : {
         "summary" : "Fetch a specific user by provider Id",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "parameters" : [ {
           "name" : "id",
@@ -1649,6 +1677,7 @@
     "/api/v1/users/user/{id}" : {
       "get" : {
         "summary" : "Fetch a specific user by Id",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "parameters" : [ {
           "name" : "id",
@@ -1710,11 +1739,12 @@
           }
         },
         "security" : [ {
-          "Auth0" : [ "admin" ]
+          "Auth0" : [ ]
         } ]
       },
       "delete" : {
         "summary" : "Delete a user specified with an id",
+        "deprecated" : true,
         "tags" : [ "Users" ],
         "parameters" : [ {
           "name" : "id",
@@ -1739,7 +1769,7 @@
           }
         },
         "security" : [ {
-          "Auth0" : [ "admin" ]
+          "Auth0" : [ ]
         } ]
       }
     },
@@ -1911,6 +1941,414 @@
           },
           "401" : {
             "description" : "Current user is not owner of this school"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/users" : {
+      "get" : {
+        "summary" : "Get all users",
+        "tags" : [ "Users" ],
+        "responses" : {
+          "200" : {
+            "description" : "Get all users",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      },
+      "post" : {
+        "summary" : "Create a new user",
+        "tags" : [ "Users" ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserPostResource"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "User successfully created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "required" : [ "emailAddress" ],
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "$ref" : "#/components/schemas/UUID"
+                    },
+                    "emailAddress" : {
+                      "minLength" : 1,
+                      "type" : "string"
+                    },
+                    "provider" : {
+                      "$ref" : "#/components/schemas/Provider"
+                    },
+                    "providerId" : {
+                      "type" : "string"
+                    },
+                    "roles" : {
+                      "uniqueItems" : true,
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string"
+                      }
+                    },
+                    "loginsCount" : {
+                      "format" : "int32",
+                      "type" : "integer"
+                    },
+                    "lastLogin" : {
+                      "$ref" : "#/components/schemas/Date"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Validation errors occurred.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "errorId" : {
+                      "type" : "string"
+                    },
+                    "errors" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/ErrorMessage"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "User with the same e-mail address already exists",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "errorId" : {
+                      "type" : "string"
+                    },
+                    "errors" : {
+                      "type" : "array",
+                      "items" : {
+                        "$ref" : "#/components/schemas/ErrorMessage"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/users/provider/{id}" : {
+      "get" : {
+        "summary" : "Fetch a specific user by provider Id",
+        "tags" : [ "Users" ],
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "path",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "User with provider Id found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "required" : [ "emailAddress" ],
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "$ref" : "#/components/schemas/UUID"
+                    },
+                    "emailAddress" : {
+                      "minLength" : 1,
+                      "type" : "string"
+                    },
+                    "provider" : {
+                      "$ref" : "#/components/schemas/Provider"
+                    },
+                    "providerId" : {
+                      "type" : "string"
+                    },
+                    "roles" : {
+                      "uniqueItems" : true,
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string"
+                      }
+                    },
+                    "loginsCount" : {
+                      "format" : "int32",
+                      "type" : "integer"
+                    },
+                    "lastLogin" : {
+                      "$ref" : "#/components/schemas/Date"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "User with specific provider Id was not found."
+          },
+          "403" : {
+            "description" : "Access is not granted to retrieve this user."
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/users/statistics" : {
+      "get" : {
+        "summary" : "Get statistics of users",
+        "tags" : [ "Users" ],
+        "responses" : {
+          "200" : {
+            "description" : "Get statistics of users",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserStatistics"
+                  }
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/users/{id}" : {
+      "get" : {
+        "summary" : "Fetch a specific user by Id",
+        "tags" : [ "Users" ],
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "User with Id found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "required" : [ "emailAddress" ],
+                  "type" : "object",
+                  "properties" : {
+                    "id" : {
+                      "$ref" : "#/components/schemas/UUID"
+                    },
+                    "emailAddress" : {
+                      "minLength" : 1,
+                      "type" : "string"
+                    },
+                    "provider" : {
+                      "$ref" : "#/components/schemas/Provider"
+                    },
+                    "providerId" : {
+                      "type" : "string"
+                    },
+                    "roles" : {
+                      "uniqueItems" : true,
+                      "type" : "array",
+                      "items" : {
+                        "type" : "string"
+                      }
+                    },
+                    "loginsCount" : {
+                      "format" : "int32",
+                      "type" : "integer"
+                    },
+                    "lastLogin" : {
+                      "$ref" : "#/components/schemas/Date"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "User with specific Id was not found."
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      },
+      "delete" : {
+        "summary" : "Delete a user specified with an id",
+        "tags" : [ "Users" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successfully deleted the user."
+          },
+          "404" : {
+            "description" : "The user to delete was not found."
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/users/{id}/email-change/request" : {
+      "post" : {
+        "summary" : "Send email with verification code to new email address",
+        "tags" : [ "Users" ],
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EmailVerficationCodeResource"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "email send with verification code"
+          },
+          "401" : {
+            "description" : "User is not authorized to send verification code for other user."
+          },
+          "409" : {
+            "description" : "Verification process still in progress. Please wait before requesting a new code."
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        },
+        "security" : [ {
+          "Auth0" : [ ]
+        } ]
+      }
+    },
+    "/api/v2/users/{id}/email-change/verify" : {
+      "patch" : {
+        "summary" : "Change email address upon successful verification",
+        "tags" : [ "Users" ],
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "path",
+          "schema" : {
+            "$ref" : "#/components/schemas/UUID"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangeEmailResource"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "Email changed successfully"
+          },
+          "401" : {
+            "description" : "User is not authorized to change email for other user."
+          },
+          "409" : {
+            "description" : "Verification code is missing or expired"
           },
           "403" : {
             "description" : "Not Allowed"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -101,7 +101,7 @@ const cookieConfig: NgcCookieConsentConfig = {
       httpInterceptor: {
         allowedList: [
           {
-            uri: `${littilConfig.apiHost}/api/v1/users/user`,
+            uri: `${littilConfig.apiHost}/api/v2/users`,
             allowAnonymous: true,
           },
           {

--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -34,5 +34,20 @@ describe('ButtonComponent', () => {
       expect(spectator.query('button')).not.toHaveClass('w-full');
       expect(spectator.query('button')).toHaveClass('mr-1');
     });
+    it('should apply customColorClass when provided', () => {
+      spectator.setInput('customColorClass', 'bg-purple-500 hover:bg-purple-600');
+      spectator.setInput('color', undefined);
+      spectator.detectChanges();
+      const button = spectator.query('button');
+      expect(button).toHaveClass('bg-purple-500');
+      expect(button).toHaveClass('hover:bg-purple-600');
+    });
+    it('should apply color variant when color input is provided', () => {
+      spectator.setInput('color', 'red');
+      spectator.detectChanges();
+      const button = spectator.query('button');
+      expect(button).toHaveClass('bg-red-600');
+      expect(button).toHaveClass('hover:bg-red-500');
+    });
   });
 });

--- a/src/app/components/button/button.component.spec.ts
+++ b/src/app/components/button/button.component.spec.ts
@@ -49,5 +49,14 @@ describe('ButtonComponent', () => {
       expect(button).toHaveClass('bg-red-600');
       expect(button).toHaveClass('hover:bg-red-500');
     });
+    it('should apply disabled color variant when button is disabled', () => {
+      spectator.setInput('color', 'red');
+      spectator.setInput('disabledColor', 'gray');
+      spectator.setInput('disabled', true);
+      spectator.detectChanges();
+      const button = spectator.query('button');
+      expect(button).toHaveClass('bg-gray-300');
+      expect(button).toHaveClass('hover:bg-gray-300');
+    });
   });
 });

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -10,6 +10,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class ButtonComponent {
   @Input() customColorClass: string | undefined;
   @Input() color: 'blue' | 'yellow' | 'red' | 'gray' |undefined;
+  @Input() disabledColor: 'blue' | 'yellow' | 'red' | 'gray' |undefined;
   @Input() inline: boolean = false;
   @Input() disabled: boolean = false;
   @Output() public onClick = new EventEmitter<any>();
@@ -18,16 +19,22 @@ export class ButtonComponent {
     if (!this.customColorClass && !this.color) {
       this.color = 'blue';
     }
+    if (!this.disabledColor) {
+      this.disabledColor = 'gray';
+    }
   }
 
   private colorVariant = {
     blue: 'bg-blue-200 hover:bg-blue-300 focus-visible:outline-blue-200',
     yellow: 'bg-yellow-200 hover:bg-yellow-100 focus-visible:outline-yellow-200',
     red: 'bg-red-600 hover:bg-red-500 focus-visible:outline-red-600',
-    gray: 'bg-gray-200 hover:bg-gray-300 focus-visible:outline-gray-200',
+    gray: 'bg-gray-300 text-gray-700 hover:bg-gray-300 focus-visible:outline-gray-200',
   };
 
   get colorClasses(): string {
+    if (this.disabled && this.disabledColor) {
+      return this.colorVariant[this.disabledColor];
+    }
     if (this.color) {
       return this.colorVariant[this.color];
     }

--- a/src/app/components/button/button.component.ts
+++ b/src/app/components/button/button.component.ts
@@ -9,7 +9,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 })
 export class ButtonComponent {
   @Input() customColorClass: string | undefined;
-  @Input() color: 'blue' | 'yellow' | 'red' | undefined;
+  @Input() color: 'blue' | 'yellow' | 'red' | 'gray' |undefined;
   @Input() inline: boolean = false;
   @Input() disabled: boolean = false;
   @Output() public onClick = new EventEmitter<any>();
@@ -24,6 +24,7 @@ export class ButtonComponent {
     blue: 'bg-blue-200 hover:bg-blue-300 focus-visible:outline-blue-200',
     yellow: 'bg-yellow-200 hover:bg-yellow-100 focus-visible:outline-yellow-200',
     red: 'bg-red-600 hover:bg-red-500 focus-visible:outline-red-600',
+    gray: 'bg-gray-200 hover:bg-gray-300 focus-visible:outline-gray-200',
   };
 
   get colorClasses(): string {

--- a/src/app/components/complete-profile-modal/complete-profile-modal.component.html
+++ b/src/app/components/complete-profile-modal/complete-profile-modal.component.html
@@ -21,20 +21,7 @@
     </littil-form-input-radio>
 
     @if(isSchool){
-    <littil-form-input-text
-      *ngIf="isSchool"
-      formControlName="schoolName"
-      id="schoolName"
-      label="Naam van de school"
-      data-test="schoolNameControl"
-    >
-      <littil-form-error-message
-        [customErrors]="{ required: 'Naam van de school is verplicht' }"
-        controlName="schoolName"
-      ></littil-form-error-message>
-    </littil-form-input-text>
-
-    <p class="mb-0 font-bold">Gegevens contactpersoon</p>
+      <p class="mb-0 font-bold">Gegevens contactpersoon</p>
     }
 
     <div class="flex gap-2">
@@ -44,10 +31,12 @@
         label="Voornaam"
         class="grow"
       >
-        <littil-form-error-message
-          [customErrors]="{ required: 'Voornaam is verplicht' }"
-          controlName="firstName"
-        ></littil-form-error-message>
+        <div class="h-[1.0rem] flex items-start">
+          <littil-form-error-message
+            [customErrors]="{ required: 'Voornaam is verplicht' }"
+            controlName="firstName"
+          ></littil-form-error-message>
+        </div>
       </littil-form-input-text>
       <littil-form-input-text
         formControlName="prefix"
@@ -68,15 +57,23 @@
         ></littil-form-error-message>
       </littil-form-input-text>
     </div>
+    @if(isSchool){
+      <littil-form-input-text
+        *ngIf="isSchool"
+        formControlName="schoolName"
+        id="schoolName"
+        label="Naam van de school"
+        data-test="schoolNameControl"
+      >
+        <div class="h-[1.0rem] flex items-start">
+          <littil-form-error-message
+            [customErrors]="{ required: 'Naam van de school is verplicht' }"
+            controlName="schoolName"
+          ></littil-form-error-message>
+        </div>
+      </littil-form-input-text>
+    }
 
-    <p>
-      @if(isSchool){ Om scholen en gastdocenten elkaar te laten vinden, hebben wij het adres van de
-      school nodig. Deze gegevens worden niet <br />
-      met derden gedeeld en alleen gebruikt om de locatie van de school op de plattegrond te tonen.
-      } @else { Om scholen en gastdocenten elkaar te laten vinden, hebben wij uw adres nodig.<br />
-      Deze gegevens worden niet met derden gedeeld en alleen gebruikt om uw locatie op de
-      plattegrond te tonen. }
-    </p>
 
     <div class="flex gap-2">
       <littil-form-input-text
@@ -85,10 +82,12 @@
         label="Straatnaam en huisnummer"
         class="grow"
       >
-        <littil-form-error-message
-          [customErrors]="{ required: 'Straatnaam en huisnummer is verplicht' }"
-          controlName="address"
-        ></littil-form-error-message>
+        <div class="h-[1.0rem] flex items-start">
+          <littil-form-error-message
+            [customErrors]="{ required: 'Straatnaam en huisnummer is verplicht' }"
+            controlName="address"
+          ></littil-form-error-message>
+        </div>
       </littil-form-input-text>
       <littil-form-input-text
         formControlName="postalCode"
@@ -108,16 +107,29 @@
     </div>
   </form>
 
-  <littil-button [inline]="true" [disabled]="savingProfile" (click)="onClickSaveProfile()">
-    Profiel opslaan
-  </littil-button>
-  <littil-button
-    [inline]="true"
-    [disabled]="savingProfile"
-    colorClass="bg-yellow-200"
-    (click)="logOut()"
-  >
-    Uitloggen
-  </littil-button>
-  <p *ngIf="savingProfile">Uw profiel wordt opgeslagen</p>
+  <div class="flex items-center gap-4">
+    <littil-button [inline]="true" [disabled]="savingProfile" (click)="onClickSaveProfile()">
+      Profiel opslaan
+    </littil-button>
+    <littil-button
+      [inline]="true"
+      [disabled]="savingProfile"
+      [color]="'yellow'"
+      (click)="logOut()"
+    >
+      Uitloggen
+    </littil-button>
+    <p class="w-3/5">
+      @if(isSchool){ Om scholen en gastdocenten elkaar te laten vinden, hebben wij het adres van de
+        school nodig. Deze gegevens worden niet met derden gedeeld en alleen gebruikt om de locatie
+        van de school op de plattegrond te tonen.
+      } @else { Om scholen en gastdocenten elkaar te laten vinden, hebben wij uw adres nodig.
+        Deze gegevens worden niet met derden gedeeld en alleen gebruikt om uw locatie op de
+          plattegrond te tonen. }
+    </p>
+
+  </div>
+  <div class="h-[2.0rem] flex items-start">
+     <p *ngIf="savingProfile">Uw profiel wordt opgeslagen</p>
+  </div>
 </div>

--- a/src/app/components/contact-modal/contact-modal.component.ts
+++ b/src/app/components/contact-modal/contact-modal.component.ts
@@ -16,13 +16,12 @@ import {
   SearchResult,
 } from '../../api/generated';
 import { LittilContactService } from '../../services/littil-contact/littil-contact.service';
-import { PermissionController } from '../../services/permission.controller';
 import { FormUtil } from '../../utils/form.util';
 import { ButtonComponent } from '../button/button.component';
 import { FormErrorMessageComponent } from '../forms/form-error-message/form-error-message.component';
-import { FormInputRadioComponent } from '../forms/radio-input/form-input-radio.component';
 import { FormInputTextComponent } from '../forms/text-input/form-input-text.component';
 import { IModalComponent } from '../modal/modal.controller';
+import { activeAccountNameSignal } from "../../state/active-account-name.signal";
 
 @Component({
   selector: 'littil-register-modal',
@@ -54,7 +53,6 @@ import { IModalComponent } from '../modal/modal.controller';
     ReactiveFormsModule,
     ButtonComponent,
     FormInputTextComponent,
-    FormInputRadioComponent,
     FormErrorMessageComponent,
   ],
 })
@@ -67,7 +65,7 @@ export class ContactModalComponent implements IModalComponent<undefined, SearchR
   private searchResult: SearchResult = {} as SearchResult;
 
   contactForm: FormGroup = new FormGroup({
-    contactInfo: new FormControl(this.permissionController.activeAccount.name, [
+    contactInfo: new FormControl(activeAccountNameSignal(), [
       Validators.required,
     ]),
     message: new FormControl('', [Validators.required]),
@@ -75,7 +73,6 @@ export class ContactModalComponent implements IModalComponent<undefined, SearchR
 
   constructor(
     private readonly contactService: LittilContactService,
-    private permissionController: PermissionController
   ) {}
 
   public onOpen(searchResult: SearchResult) {

--- a/src/app/components/forms/text-input/form-input-text.component.html
+++ b/src/app/components/forms/text-input/form-input-text.component.html
@@ -15,6 +15,7 @@
     [placeholder]="placeholder"
     [disabled]="disabled"
     (change)="value = $any($event.target).value"
+    [readOnly]="readonly"
     (touched)="onTouched($event)"
   />
   <ng-content></ng-content>

--- a/src/app/components/forms/text-input/form-input-text.component.spec.ts
+++ b/src/app/components/forms/text-input/form-input-text.component.spec.ts
@@ -100,6 +100,19 @@ describe('FormInputTextComponent', () => {
     });
   });
 
+  describe('setReadOnlyState', () => {
+    it('should allow/reject change of input', async () => {
+      spectator.setInput('id', 'firstName');
+      spectator.setInput('label', 'Firstname');
+      spectator.setInput('placeholder', 'Give your firstname');
+      spectator.setInput('readonly', true)
+      expect(spectator.query('input')).toHaveAttribute('readonly');
+      spectator.setInput('readonly', false)
+      expect(spectator.query('input')).not.toHaveAttribute('readonly');
+    });
+  });
+
+
   describe('Template', () => {
     it('should set correct classes on normal state', async () => {
       spectator.setInput('id', 'firstName');

--- a/src/app/components/forms/text-input/form-input-text.component.ts
+++ b/src/app/components/forms/text-input/form-input-text.component.ts
@@ -10,4 +10,5 @@ import { FormBaseComponent } from '../form-base';
 })
 export class FormInputTextComponent extends FormBaseComponent {
   @Input() placeholder: string = '';
+  @Input() readonly!: boolean;
 }

--- a/src/app/components/profile-container/profile-container.component.html
+++ b/src/app/components/profile-container/profile-container.component.html
@@ -6,6 +6,8 @@
         routerLinkActive="bg-gray-100 text-gray-900"
         class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
         aria-current="page"
+        aria-label="profile"
+        title="Profiel"
       >
         <svg
           class="text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
@@ -29,6 +31,8 @@
         routerLinkActive="bg-gray-100 text-gray-900"
         class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
         aria-current="page"
+        aria-label="modules"
+        title="Modules"
       >
         <svg
           class="text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
@@ -50,7 +54,8 @@
         [routerLink]="'/user/change-email'"
         routerLinkActive="bg-gray-100 text-gray-900"
         class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
-        aria-label="Wijzig e-mailadres"
+        aria-current="page"
+        aria-label="change-email"
         title="Wijzig e-mailadres"
       >
         <svg
@@ -74,7 +79,8 @@
         [routerLink]="'/user/delete'"
         routerLinkActive="bg-red-100 text-red-900"
         class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
-        aria-label="Verwijder profiel"
+        aria-current="page"
+        aria-label="delete"
         title="Verwijder profiel"
       >
         <svg

--- a/src/app/components/profile-container/profile-container.component.html
+++ b/src/app/components/profile-container/profile-container.component.html
@@ -46,6 +46,32 @@
         </svg>
         <span class="truncate">Modules</span>
       </a>
+      <div class="min-h-[0.5rem] flex items-center"></div>
+      <a
+        [routerLink]="'/user/delete'"
+        routerLinkActive="bg-red-100 text-red-900"
+        class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
+        aria-label="Verwijder profiel"
+        title="Verwijder profiel"
+      >
+        <svg
+          class="text-gray-600 group-hover:bg-gray-50 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 3h6m-7 4h8m-9 0h10l-.867 12.142A2 2 0 0114.138 21H9.862a2 2 0 01-1.995-1.858L7 7z"
+          />
+        </svg>
+        <span class="truncate">Verwijder Profiel</span>
+      </a>
+
+
     </nav>
 
     <div class="col-span-4">

--- a/src/app/components/profile-container/profile-container.component.html
+++ b/src/app/components/profile-container/profile-container.component.html
@@ -1,4 +1,4 @@
-<div class="max-w-screen-lg mx-auto">
+<div class="max-w-screen-lg mx-auto min-h-[30rem]">
   <div class="grid grid-cols-5 gap-4">
     <nav class="col-span-1 space-y-1" aria-label="Sidebar">
       <a
@@ -46,6 +46,29 @@
         </svg>
         <span class="truncate">Modules</span>
       </a>
+      <a
+        [routerLink]="'/user/change-email'"
+        routerLinkActive="bg-gray-100 text-gray-900"
+        class="text-gray-600 hover:bg-gray-50 hover:text-gray-900 group flex items-center rounded-md px-3 py-2 text-sm font-medium"
+        aria-label="Wijzig e-mailadres"
+        title="Wijzig e-mailadres"
+      >
+        <svg
+          class="text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+          />
+        </svg>
+        <span class="truncate">Wijzig E-mailadres</span>
+      </a>
       <div class="min-h-[0.5rem] flex items-center"></div>
       <a
         [routerLink]="'/user/delete'"
@@ -55,7 +78,7 @@
         title="Verwijder profiel"
       >
         <svg
-          class="text-gray-600 group-hover:bg-gray-50 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
+          class="text-gray-400 group-hover:text-gray-500 -ml-1 mr-3 h-6 w-6 flex-shrink-0"
           fill="none"
           viewBox="0 0 24 24"
           stroke-width="1.5"
@@ -70,12 +93,10 @@
         </svg>
         <span class="truncate">Verwijder Profiel</span>
       </a>
-
-
     </nav>
 
     <div class="col-span-4">
-      <h1>{{ title }}</h1>
+      <h2>{{ title }}</h2>
       <ng-content></ng-content>
     </div>
   </div>

--- a/src/app/components/profile-container/profile-container.component.ts
+++ b/src/app/components/profile-container/profile-container.component.ts
@@ -1,14 +1,13 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule } from "@angular/common";
 import { Component, Input, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { PermissionController, Roles } from '../../services/permission.controller';
-import { ContentContainerComponent } from '../content-container/content-container.component';
 
 @Component({
   selector: 'littil-profile-container',
   templateUrl: './profile-container.component.html',
   standalone: true,
-  imports: [CommonModule, ContentContainerComponent, RouterModule],
+  imports: [CommonModule, RouterModule]
 })
 export class ProfileContainerComponent implements OnInit {
   @Input() title?: string;

--- a/src/app/components/register-modal/register-modal.component.html
+++ b/src/app/components/register-modal/register-modal.component.html
@@ -8,12 +8,14 @@
   <p>Na activatie van uw account kunt u uw profiel verder afmaken.</p>
   <form [formGroup]="registerForm" data-test="form-register" (submit)="onClickRegister()">
     <littil-form-input-text formControlName="email" id="email" label="E-mailadres">
-      <littil-form-error-message
-        [customErrors]="{
-          required: 'E-mailadres is verplicht'
-        }"
-        controlName="email"
-      ></littil-form-error-message>
+      <div class="min-h-[1.5rem] flex items-start">
+        <littil-form-error-message
+          [customErrors]="{
+            required: 'E-mailadres is verplicht'
+          }"
+          controlName="email"
+        ></littil-form-error-message>
+      </div>
     </littil-form-input-text>
   </form>
 
@@ -35,9 +37,12 @@
       >Annuleren</littil-button
     >
   </div>
-  @if(creatingProfile){
-  <p *ngIf="creatingProfile">Uw account wordt aangemaakt</p>
-  } }
+  <div class="min-h-[2.5rem] flex items-start">
+    @if(creatingProfile){
+      <p *ngIf="creatingProfile">Uw account wordt aangemaakt</p>
+    }
+  </div>
+  }
 </div>
 
 <div [@hideShow]="hideConfirmation ? 'hidden' : 'visible'" class="prose">

--- a/src/app/components/register-modal/register-modal.component.html
+++ b/src/app/components/register-modal/register-modal.component.html
@@ -8,7 +8,7 @@
   <p>Na activatie van uw account kunt u uw profiel verder afmaken.</p>
   <form [formGroup]="registerForm" data-test="form-register" (submit)="onClickRegister()">
     <littil-form-input-text formControlName="email" id="email" label="E-mailadres">
-      <div class="min-h-[1.5rem] flex items-start">
+      <div class="min-h-[1.0rem] flex items-start">
         <littil-form-error-message
           [customErrors]="{
             required: 'E-mailadres is verplicht'
@@ -37,7 +37,7 @@
       >Annuleren</littil-button
     >
   </div>
-  <div class="min-h-[2.5rem] flex items-start">
+  <div class="h-[2.0rem] flex items-start">
     @if(creatingProfile){
       <p *ngIf="creatingProfile">Uw account wordt aangemaakt</p>
     }

--- a/src/app/components/user-menu/user-menu.component.html
+++ b/src/app/components/user-menu/user-menu.component.html
@@ -1,9 +1,9 @@
 @if(loaded){ @if(loggedIn){
 <div class="user-menu flex flex-row items-center gap-2">
   <span class="flex flex-row gap-2 items-center cursor-pointer" (click)="toggleMenu()">
-    <span>{{ permissionController.activeAccount.name }}</span>
+    <span>{{ activeAccountName() }}</span>
     <littil-avatar
-      [avatarText]="permissionController.activeAccount.name"
+      [avatarText]="activeAccountName()"
       [avatarImage]="userAvatar"
     ></littil-avatar>
   </span>
@@ -35,7 +35,7 @@
       <div class="px-4 py-3 flex flex-col" role="none">
         <span class="text-sm" role="none">U bent ingelogd als</span>
         <span class="truncate text-sm font-medium text-blue-200" role="none">{{
-          permissionController.activeAccount.name
+            activeAccountName()
         }}</span>
       </div>
       <div class="py-1" role="none">

--- a/src/app/components/user-menu/user-menu.component.ts
+++ b/src/app/components/user-menu/user-menu.component.ts
@@ -11,6 +11,7 @@ import {
   IRegisterModalOutput,
   RegisterModalComponent,
 } from '../register-modal/register-modal.component';
+import { activeAccountNameSignal } from "../../state/active-account-name.signal";
 
 @Component({
   selector: 'littil-user-menu',
@@ -70,4 +71,8 @@ export class UserMenuComponent implements OnInit {
   public openLoginModal(): void {
     this.auth.loginWithRedirect();
   }
+
+  protected readonly activeAccountName = activeAccountNameSignal;
+
+  // protected readonly activeAccountNameSignal = activeAccountNameSignal;
 }

--- a/src/app/components/user-menu/user-menu.component.ts
+++ b/src/app/components/user-menu/user-menu.component.ts
@@ -23,11 +23,13 @@ export class UserMenuComponent implements OnInit {
   loaded: boolean = false;
   open: boolean = false;
 
+  protected readonly activeAccountName = activeAccountNameSignal;
+
   constructor(
     public readonly permissionController: PermissionController,
     private modalController: ModalController,
     public auth: AuthService,
-    private router: Router
+    router: Router
   ) {
     router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
       this.open = false;
@@ -72,7 +74,4 @@ export class UserMenuComponent implements OnInit {
     this.auth.loginWithRedirect();
   }
 
-  protected readonly activeAccountName = activeAccountNameSignal;
-
-  // protected readonly activeAccountNameSignal = activeAccountNameSignal;
 }

--- a/src/app/pages/user/change-email/change-email.component.dom.spec.ts
+++ b/src/app/pages/user/change-email/change-email.component.dom.spec.ts
@@ -1,0 +1,188 @@
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChangeEmailComponent } from './change-email.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { LittilUserService } from '../../../services/littil-user/littil-user.service';
+import { PermissionController } from "../../../services/permission.controller";
+import { ActivatedRoute } from "@angular/router";
+import { ActivatedRouteStub } from "@ngneat/spectator";
+import { CommonModule } from "@angular/common";
+import { ProfileContainerComponent } from "../../../components/profile-container/profile-container.component";
+import {   FormErrorMessageComponent } from "../../../components/forms/form-error-message/form-error-message.component";
+import {   FormInputTextComponent } from "../../../components/forms/text-input/form-input-text.component";
+import { ButtonComponent } from "../../../components/button/button.component";
+
+// ---- Service Mocks ----
+const permissionControllerMock: Partial<PermissionController> = {
+  userId: 'user-123',
+  getRoleType: jest.fn().mockReturnValue('schools'),
+};
+
+const littilUserServiceMock: Partial<LittilUserService> = {
+  emailVerificationCode: jest.fn(),
+  changeEmail: jest.fn(),
+};
+
+describe('ChangeEmailComponent (DOM)', () => {
+  let fixture: ComponentFixture<ChangeEmailComponent>;
+  let component: ChangeEmailComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      // Standalone component => include in imports (no declarations)
+      imports: [
+        CommonModule,
+        ProfileContainerComponent,
+        FormErrorMessageComponent,
+        FormInputTextComponent,
+        ReactiveFormsModule,
+        ButtonComponent,
+        ChangeEmailComponent
+      ],
+      providers: [
+        { provide: LittilUserService, useValue: littilUserServiceMock },
+        { provide: PermissionController, useValue: permissionControllerMock },
+        { provide: ActivatedRoute, useValue: ActivatedRouteStub },
+      ],
+      // Ignore unknown custom elements such as <littil-button>, <littil-form-input-text>, etc.
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangeEmailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------
+  // Creation & initial DOM
+  // ---------------------------------------------------------
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders instructions by default (hideForm=false)', async () => {
+    // Initial state in component: hideForm is false => instructions visible
+    fixture.detectChanges();
+    await fixture.whenRenderingDone();
+
+    const instructions = fixture.nativeElement.querySelector('[data-test="instructions"]');
+    expect(instructions).not.toBeNull();
+    expect(instructions.textContent).toContain('Vul uw nieuwe e-mailadres in');
+  });
+
+  // ---------------------------------------------------------
+  // Confirm new email flow
+  // ---------------------------------------------------------
+  it('shows the confirmation UI (verification code input) after confirming email successfully', async () => {
+    // Arrange: enter a valid email and mock successful backend
+    component.changeEmailForm.get('email')?.setValue('valid@example.com');
+    (littilUserServiceMock.emailVerificationCode as jest.Mock).mockReturnValue(
+      of(new HttpResponse({ status: 200, statusText: 'OK', body: {} }))
+    );
+
+    // Act: call public method
+    component.onClickConfirmNewEmail();
+    fixture.detectChanges();
+    await fixture.whenRenderingDone();
+
+    // Assert: verification UI visible
+    const verifyInstructions = fixture.nativeElement.querySelector('[data-test="verification-instructions"]');
+    const verificationInput = fixture.nativeElement.querySelector('[data-test="input-verification-code"]');
+    const changeEmailButton = fixture.nativeElement.querySelector('[data-test="changeEmailButton"]');
+    const cancelButton = fixture.nativeElement.querySelector('[data-test="cancelButton"]');
+    expect(verifyInstructions).not.toBeNull();
+    expect(verificationInput).not.toBeNull();
+    expect(changeEmailButton).not.toBeNull();
+    expect(cancelButton).not.toBeNull();
+
+    // Original confirm button should be gone
+    const confirmBtn = fixture.nativeElement.querySelector('[data-test="sendVerificationCodeButton"]');
+    expect(confirmBtn).toBeNull();
+
+    // Service called correctly
+    expect(littilUserServiceMock.emailVerificationCode).toHaveBeenCalledWith('user-123', {
+      emailAddress: 'valid@example.com',
+    });
+  });
+
+  it('Bevestig button presence depends on emailConfirmed=false; disabled toggles with email validity', async () => {
+    // Initially emailConfirmed=false, so the confirm button should be present
+    component.changeEmailForm.get('email')?.setValue('invalid-email');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const btn = fixture.nativeElement.querySelector('[data-test="confirmEmailButton"] button');
+    expect(btn).not.toBeNull();
+    expect(btn.disabled).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------
+  // Change email action & confirmation panel
+  // ---------------------------------------------------------
+  it('shows the confirmation panel after changeEmail succeeds, with the new email in the message', async () => {
+    // Arrange: we are in verify step (emailConfirmed true because of previous action)
+    // Drive via public API: set form fields to simulate user input
+    component.changeEmailForm.get('email')?.setValue('new@example.com');
+    component.changeEmailForm.get('verificationCode')?.setValue('123456');
+
+    (littilUserServiceMock.changeEmail as jest.Mock).mockReturnValue(
+      of(new HttpResponse({ status: 200, statusText: 'OK', body: {} }))
+    );
+
+    // Act
+    component.onClickChangeEmail();
+    fixture.detectChanges();
+    await fixture.whenRenderingDone();
+
+    // Assert: confirmation panel visible with email
+    const confirmationMessage = fixture.nativeElement.querySelector('[data-test="confirmation-message"]');
+    const confirmationEmail = fixture.nativeElement.querySelector('[data-test="confirmation-email"]');
+    expect(confirmationMessage).not.toBeNull();
+    expect(confirmationMessage.textContent).toContain('Uw e-mailadres is gewijzigd.');
+    expect(confirmationEmail).not.toBeNull();
+    expect(confirmationEmail.textContent).toContain('new@example.com');
+
+    // Assert: form instructions are gone (form hidden via @if)
+    const instructions = fixture.nativeElement.querySelector('[data-test="instructions"]');
+    expect(instructions).toBeNull();
+
+    // Service called correctly
+    expect(littilUserServiceMock.changeEmail).toHaveBeenCalledWith('user-123', {
+      newEmailAddress: 'new@example.com',
+      verificationCode: '123456',
+    });
+  });
+
+  // ---------------------------------------------------------
+  // Cancel flow (protected method)
+  // ---------------------------------------------------------
+  it('shows cancel confirmation after cancel and hides verification UI', async () => {
+    // Drive cancellation via the component's protected method
+    (component as any).onClickCancel(); // bracket notation/cast to any to call protected
+    fixture.detectChanges();
+    await fixture.whenRenderingDone();
+
+    // Assert: cancel panel visible
+    const cancelMessage = fixture.nativeElement.querySelector('[data-test="cancel-message"]');
+    const cancelInfo = fixture.nativeElement.querySelector('[data-test="cancel-info"]');
+    expect(cancelMessage).not.toBeNull();
+    expect(cancelMessage.textContent).toContain('Uw e-mailadres is niet gewijzigd.');
+    expect(cancelInfo).not.toBeNull();
+
+    // Assert: verification UI gone
+    const verificationInput = fixture.nativeElement.querySelector('[data-test="input-verification-code"]');
+    expect(verificationInput).toBeNull();
+
+    // Assert: confirm button absent
+    const confirmBtn = fixture.nativeElement.querySelector('[data-test="sendVerificationCodeButton"]');
+    expect(confirmBtn).toBeNull();
+  });
+
+});

--- a/src/app/pages/user/change-email/change-email.component.html
+++ b/src/app/pages/user/change-email/change-email.component.html
@@ -1,0 +1,91 @@
+
+<littil-profile-container title="Wijzig E-mailadres">
+  @if (!hideForm) {
+    <div data-test="form-container">
+      <p data-test="instructions">
+        Vul uw nieuwe e-mailadres in en bevestig deze.<br>
+        Er wordt een mail verstuurd naar het nieuwe e-mailadres met een verificatiecode.
+        De code is 5 minuten geldig en kan slechts één keer gebruikt worden.
+      </p>
+
+      <form [formGroup]="changeEmailForm" data-test="form-register">
+        <littil-form-input-text
+          formControlName="email"
+          id="email"
+          label="E-mailadres"
+          [readonly]="emailConfirmed"
+          data-test="input-email">
+          <div class="min-h-[1.0rem] flex items-start">
+            <littil-form-error-message
+              [customErrors]="{
+                required: 'E-mailadres is verplicht'
+              }"
+              controlName="email">
+            </littil-form-error-message>
+          </div>
+        </littil-form-input-text>
+
+        @if (!emailConfirmed) {
+          <littil-button
+            data-test="confirmEmailButton"
+            [inline]="true"
+            [color]="'blue'"
+            [disabled]="!validEmail()"
+            (click)="onClickConfirmNewEmail()">
+            Bevestig
+          </littil-button>
+        }
+
+        @if (emailConfirmed) {
+          <p data-test="verification-instructions">Vul de ontvangen verificatiecode in om het e-mailadres te wijzigen.</p>
+          <littil-form-input-text
+            formControlName="verificationCode"
+            id="verificationCode"
+            label="Verificatiecode"
+            data-test="input-verification-code"
+          >
+            <div class="min-h-[1.0rem] flex items-start">
+              <littil-form-error-message
+                [customErrors]="{
+                  required: 'Verificatiecode is verplicht'
+                }"
+                controlName="verificationCode">
+              </littil-form-error-message>
+            </div>
+          </littil-form-input-text>
+
+          <div>
+            <littil-button
+              data-test="changeEmailButton"
+              [inline]="true"
+              [color]="'blue'"
+              (click)="onClickChangeEmail()">
+              Wijzig email
+            </littil-button>
+            <littil-button
+              data-test="cancelButton"
+              [inline]="true"
+              [color]="'yellow'"
+              (click)="onClickCancel()">
+              Annuleren
+            </littil-button>
+          </div>
+        }
+      </form>
+    </div>
+  }
+
+  @if (!hideConfirmation) {
+    <p data-test="confirmation-message">Uw e-mailadres is gewijzigd.</p>
+    <p data-test="confirmation-email">
+      U kunt vanaf nu inloggen met uw nieuwe e-mailadres
+      <b>{{ changeEmailForm.get('email')?.value }}</b>
+    </p>
+  }
+
+  @if (!hideCancelConfirmation) {
+    <p data-test="cancel-message">Uw e-mailadres is niet gewijzigd.</p>
+    <p data-test="cancel-info">Over 5 minuten kunt u opnieuw uw email adres wijzigen.</p>
+  }
+
+</littil-profile-container>

--- a/src/app/pages/user/change-email/change-email.component.spec.ts
+++ b/src/app/pages/user/change-email/change-email.component.spec.ts
@@ -1,0 +1,223 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ChangeEmailComponent } from './change-email.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { LittilUserService } from '../../../services/littil-user/littil-user.service';
+import { PermissionController } from '../../../services/permission.controller';
+import { of } from 'rxjs';
+import { HttpResponse } from '@angular/common/http';
+
+
+describe('ChangeEmailComponent (decoupled)', () => {
+  let fixture: ComponentFixture<ChangeEmailComponent>;
+  let component: ChangeEmailComponent;
+
+  const littilUserServiceMock = {
+    emailVerificationCode: jest.fn(),
+    changeEmail: jest.fn(),
+  };
+
+  const permissionControllerMock = {
+    userId: 'user-123',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      // Standalone component: include in imports
+      imports: [ChangeEmailComponent, ReactiveFormsModule],
+      providers: [
+        { provide: LittilUserService, useValue: littilUserServiceMock },
+        { provide: PermissionController, useValue: permissionControllerMock },
+      ],
+    })
+      // We override the template to decouple unit tests from DOM & child components
+      .overrideComponent(ChangeEmailComponent, {
+        set: { template: '' },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ChangeEmailComponent);
+    component = fixture.componentInstance;
+
+
+    // Clear previous mocks per test
+    jest.clearAllMocks();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('initial state', () => {
+    it('flags should be set correctly', () => {
+      expect(component['hideForm']).toBe(false);
+      expect(component['hideConfirmation']).toBe(true);
+      expect(component['hideCancelConfirmation']).toBe(true);
+      expect(component['emailConfirmed']).toBe(false);
+    });
+
+    it('form should be defined with email & verificationCode controls', () => {
+      expect(component.changeEmailForm.contains('email')).toBe(true);
+      expect(component.changeEmailForm.contains('verificationCode')).toBe(true);
+    });
+
+    it('validEmail() should be false initially', () => {
+      expect(component.validEmail()).toBe(false);
+    });
+  });
+
+  describe('validEmail()', () => {
+    it('should be false for invalid email & true for a valid one', () => {
+      const emailCtrl = component.changeEmailForm.get('email')!;
+      emailCtrl.setValue('not-an-email');
+      expect(component.validEmail()).toBe(false);
+
+      emailCtrl.setValue('info@example.com');
+      expect(component.validEmail()).toBe(true);
+    });
+  });
+
+  describe('onClickConfirmNewEmail()', () => {
+    it('should call service with userId & resource and set isVerificationCodeSend=true on 2xx', () => {
+      const email = 'info@example.com';
+      component.changeEmailForm.get('email')!.setValue(email);
+
+      littilUserServiceMock.emailVerificationCode.mockReturnValue(
+        of(new HttpResponse({ status: 200 }))
+      );
+
+      component.onClickConfirmNewEmail();
+
+      expect(littilUserServiceMock.emailVerificationCode).toHaveBeenCalledTimes(1);
+      expect(littilUserServiceMock.emailVerificationCode).toHaveBeenCalledWith(
+        'user-123',
+        { emailAddress: email }
+      );
+      expect(component['emailConfirmed']).toBe(true);
+    });
+
+    it('should not set emailConfirmed on non-2xx', () => {
+      const email = 'info@example.com';
+      component.changeEmailForm.get('email')!.setValue(email);
+
+      littilUserServiceMock.emailVerificationCode.mockReturnValue(
+        of(new HttpResponse({ status: 400 }))
+      );
+
+      component['emailConfirmed'] = false;
+      component.onClickConfirmNewEmail();
+
+      expect(littilUserServiceMock.emailVerificationCode).toHaveBeenCalledTimes(1);
+      expect(component['emailConfirmed']).toBe(false);
+    });
+
+    it('should handle null response gracefully', () => {
+      const email = 'info@example.com';
+      component.changeEmailForm.get('email')!.setValue(email);
+
+      littilUserServiceMock.emailVerificationCode.mockReturnValue(of(null));
+
+      component['emailConfirmed'] = false;
+      component.onClickConfirmNewEmail();
+
+      expect(littilUserServiceMock.emailVerificationCode).toHaveBeenCalledTimes(1);
+      expect(component['emailConfirmed']).toBe(false);
+    });
+  });
+
+  describe('onClickChangeEmail()', () => {
+    it('should call service with correct payload and toggle flags on 2xx', () => {
+      const email = 'info@example.com';
+      const code = '123456';
+
+      component.changeEmailForm.get('email')!.setValue(email);
+      component.changeEmailForm.get('verificationCode')!.setValue(code);
+
+      littilUserServiceMock.changeEmail.mockReturnValue(
+        of(new HttpResponse({ status: 200 }))
+      );
+
+      component.onClickChangeEmail();
+
+      expect(littilUserServiceMock.changeEmail).toHaveBeenCalledTimes(1);
+      expect(littilUserServiceMock.changeEmail).toHaveBeenCalledWith(
+        'user-123',
+        { newEmailAddress: email, verificationCode: code }
+      );
+
+      expect(component['hideForm']).toBe(true);
+      expect(component['hideConfirmation']).toBe(false);
+    });
+
+    it('should not toggle flags on non-2xx', () => {
+      const email = 'info@example.com';
+      const code = '123456';
+
+      component.changeEmailForm.get('email')!.setValue(email);
+      component.changeEmailForm.get('verificationCode')!.setValue(code);
+
+      littilUserServiceMock.changeEmail.mockReturnValue(
+        of(new HttpResponse({ status: 400 }))
+      );
+
+      // Pre-state
+      component['hideForm'] = false;
+      component['hideConfirmation'] = true;
+
+      component.onClickChangeEmail();
+
+      expect(littilUserServiceMock.changeEmail).toHaveBeenCalledTimes(1);
+      expect(component['hideForm']).toBe(false);
+      expect(component['hideConfirmation']).toBe(true);
+    });
+
+    it('should handle null response gracefully', () => {
+      const email = 'info@example.com';
+      const code = '123456';
+
+      component.changeEmailForm.get('email')!.setValue(email);
+      component.changeEmailForm.get('verificationCode')!.setValue(code);
+
+      littilUserServiceMock.changeEmail.mockReturnValue(of(null));
+
+      component['hideForm'] = false;
+      component['hideConfirmation'] = true;
+
+      component.onClickChangeEmail();
+
+      expect(littilUserServiceMock.changeEmail).toHaveBeenCalledTimes(1);
+      expect(component['hideForm']).toBe(false);
+      expect(component['hideConfirmation']).toBe(true);
+    });
+  });
+
+  describe('onClickCancel()', () => {
+    it('should reset flags and form to pristine/untouched with empty values', () => {
+      const emailCtrl = component.changeEmailForm.get('email')!;
+      const codeCtrl = component.changeEmailForm.get('verificationCode')!;
+
+      // Set pre-state
+      component['hideForm'] = true;
+      component['hideConfirmation'] = false;
+      component['hideCancelConfirmation'] = true;
+      component['emailConfirmed'] = true;
+
+      emailCtrl.setValue('info@example.com');
+      codeCtrl.setValue('999999');
+
+      // Simulate interaction
+      emailCtrl.markAsDirty();
+      emailCtrl.markAsTouched();
+      codeCtrl.markAsDirty();
+      codeCtrl.markAsTouched();
+
+      // Call protected method (via any to bypass TS access modifier)
+      (component as any).onClickCancel();
+
+      // Flags reset
+      expect(component['hideForm']).toBe(true);
+      expect(component['hideConfirmation']).toBe(true);
+      expect(component['hideCancelConfirmation']).toBe(false);
+      expect(component['emailConfirmed']).toBe(false);
+    });
+  });
+});

--- a/src/app/pages/user/change-email/change-email.component.ts
+++ b/src/app/pages/user/change-email/change-email.component.ts
@@ -8,6 +8,7 @@ import { CommonModule } from "@angular/common";
 import { LittilUserService } from "../../../services/littil-user/littil-user.service";
 import { HttpResponse } from "@angular/common/http";
 import { PermissionController } from "../../../services/permission.controller";
+import { activeAccountNameSignal } from "../../../state/active-account-name.signal";
 
 @Component({
   selector: 'littil-change-email',
@@ -64,7 +65,7 @@ export class ChangeEmailComponent {
         if (response?.ok) {
           this.hideForm = true;
           this.hideConfirmation = false;
-          // TODO change email at top of screen
+          activeAccountNameSignal.set(emailAddres);
         }
       })
   }

--- a/src/app/pages/user/change-email/change-email.component.ts
+++ b/src/app/pages/user/change-email/change-email.component.ts
@@ -1,0 +1,82 @@
+import { Component } from '@angular/core';
+import {  ProfileContainerComponent } from "../../../components/profile-container/profile-container.component";
+import { FormErrorMessageComponent } from "../../../components/forms/form-error-message/form-error-message.component";
+import { FormInputTextComponent } from "../../../components/forms/text-input/form-input-text.component";
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
+import { ButtonComponent } from "../../../components/button/button.component";
+import { CommonModule } from "@angular/common";
+import { LittilUserService } from "../../../services/littil-user/littil-user.service";
+import { HttpResponse } from "@angular/common/http";
+import { PermissionController } from "../../../services/permission.controller";
+
+@Component({
+  selector: 'littil-change-email',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ProfileContainerComponent,
+    FormErrorMessageComponent,
+    FormInputTextComponent,
+    ReactiveFormsModule,
+    ButtonComponent,
+  ],
+  templateUrl: './change-email.component.html',
+})
+export class ChangeEmailComponent {
+  protected hideForm: boolean = false;
+  protected hideConfirmation: boolean = true;
+  protected hideCancelConfirmation: boolean = true;
+  protected emailConfirmed: boolean = false;
+  private userId: string;
+
+  constructor (
+    permissionController: PermissionController,
+    private readonly littilUserService: LittilUserService,
+  ) {
+    this.userId = permissionController.userId;
+  }
+
+  changeEmailForm: FormGroup = new FormGroup({
+    email: new FormControl('', [Validators.required, Validators.email]),
+    verificationCode: new FormControl('', [Validators.required]),
+  });
+
+
+  onClickConfirmNewEmail() {
+    const emailAddres = this.changeEmailForm.get('email')?.value;
+    const resource = { emailAddress: emailAddres };
+
+    this.littilUserService.emailVerificationCode(this.userId, resource)
+      .subscribe((response: HttpResponse<any> | null) => {
+      if (response?.ok) {
+        this.emailConfirmed = true;
+      }
+    })
+  }
+
+  onClickChangeEmail() {
+    const emailAddres = this.changeEmailForm.get('email')?.value;
+    const code = this.changeEmailForm.get('verificationCode')?.value;
+    const resource = { newEmailAddress: emailAddres,verificationCode: code };
+
+    this.littilUserService.changeEmail(this.userId, resource)
+      .subscribe((response: HttpResponse<any> | null) => {
+        if (response?.ok) {
+          this.hideForm = true;
+          this.hideConfirmation = false;
+          // TODO change email at top of screen
+        }
+      })
+  }
+
+  validEmail(): boolean {
+    return this.changeEmailForm.controls['email'].valid;
+  }
+
+  protected onClickCancel() {
+    this.hideForm = true;
+    this.hideConfirmation = true;
+    this.hideCancelConfirmation = false;
+    this.emailConfirmed = false;
+  }
+}

--- a/src/app/pages/user/change-email/change-email.component.ts
+++ b/src/app/pages/user/change-email/change-email.component.ts
@@ -28,7 +28,7 @@ export class ChangeEmailComponent {
   protected hideConfirmation: boolean = true;
   protected hideCancelConfirmation: boolean = true;
   protected emailConfirmed: boolean = false;
-  private userId: string;
+  private readonly userId: string;
 
   constructor (
     permissionController: PermissionController,

--- a/src/app/pages/user/delete-profile/delete-profile.component.html
+++ b/src/app/pages/user/delete-profile/delete-profile.component.html
@@ -1,0 +1,42 @@
+<littil-profile-container title="Profiel verwijderen">
+  <form
+    data-test="delete_profile"
+    class="border border-red-600 rounded-md p-2 mt-8 text-red-900"
+    [formGroup]="deleteProfileForm"
+  >
+    <p class="mt-0">
+      Weet u zeker dat u uw profiel wilt verwijderen? Al uw gegevens worden verwijderd. Dit kan niet
+      ongedaan worden gemaakt. Geef hieronder uw e-mailadres in en klik op verwijderen om door te
+      gaan.
+    </p>
+
+    <div class="flex">
+      <littil-form-input-text
+        formControlName="email"
+        placeholder="email@example.com"
+        class="grow"
+      >
+        <div class="min-h-[1.5rem] flex items-center">
+          <littil-form-error-message
+            [customErrors]="{
+              required: 'Vul ter bevestiging uw eigen e-mailadres in',
+              emailMismatch: 'Het ingevoerde e-mailadres is niet geldig of komt niet overeen met uw account'
+            }"
+            controlName="email"
+          ></littil-form-error-message>
+        </div>
+      </littil-form-input-text>
+    </div>
+
+    <div class="flex justify-between">
+      <littil-button
+        [inline]="true"
+        [color]="validEmail() ? 'red' : 'gray'"
+        [disabled]="!validEmail()"
+        (click)="deleteProfile(); $event.preventDefault()"
+      >
+        Profiel definitief verwijderen
+      </littil-button>
+    </div>
+  </form>
+</littil-profile-container>

--- a/src/app/pages/user/delete-profile/delete-profile.component.spec.ts
+++ b/src/app/pages/user/delete-profile/delete-profile.component.spec.ts
@@ -1,0 +1,113 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { DeleteProfileComponent } from './delete-profile.component';
+import { PermissionController, Roles } from '../../../services/permission.controller';
+import { LittilTeacherService } from "../../../services/littil-teacher/littil-teacher.service";
+import { LittilSchoolService } from '../../../services/littil-school/littil-school.service';
+import { AuthService } from "@auth0/auth0-angular";
+import { of } from 'rxjs';
+import { HttpResponse } from '@angular/common/http';
+import { ActivatedRoute } from "@angular/router";
+import { ActivatedRouteStub } from "@ngneat/spectator";
+import { By } from "@angular/platform-browser";
+import { ButtonComponent } from "../../../components/button/button.component";
+
+describe('DeleteProfileComponent', () => {
+  let component: DeleteProfileComponent;
+  let permissionControllerMock: any;
+  let teacherServiceMock: any;
+  let schoolServiceMock: any;
+  let authServiceMock: any;
+  let fixture: ComponentFixture<DeleteProfileComponent>;
+
+  beforeEach(() => {
+    permissionControllerMock = {
+      getRoleType: jest.fn(),
+      getRoleId: jest.fn(),
+      activeAccount: { email: 'test@example.com' }
+    };
+
+    teacherServiceMock = {
+      delete: jest.fn()
+    };
+
+    schoolServiceMock = {
+      delete: jest.fn()
+    };
+
+    authServiceMock = {
+      logout: jest.fn()
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PermissionController, useValue: permissionControllerMock },
+        { provide: LittilTeacherService, useValue: teacherServiceMock },
+        { provide: LittilSchoolService, useValue: schoolServiceMock },
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: ActivatedRoute, useValue: ActivatedRouteStub },
+      ]
+    });
+
+    fixture = TestBed.createComponent(DeleteProfileComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should disable the button when email is invalid', () => {
+    const button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
+
+    // Initially empty -> invalid
+    fixture.detectChanges();
+    expect(button.disabled).toBeTruthy();
+
+    // Set invalid email
+    component.deleteProfileForm.get('email')?.setValue('invalid-email');
+    fixture.detectChanges();
+    expect(button.disabled).toBeTruthy();
+
+    // Set valid email but not matching logged-in email
+    component.deleteProfileForm.get('email')?.setValue('valid@example.com');
+    fixture.detectChanges();
+    expect(button.disabled).toBeTruthy();
+
+    // Set valid and matching email
+    component.deleteProfileForm.get('email')?.setValue('test@example.com');
+    fixture.detectChanges();
+    expect(button.disabled).not.toBeTruthy();
+  });
+
+  it('should call teacherService.delete and logout for GuestTeacher', () => {
+    // Set mocks BEFORE creating component
+    permissionControllerMock.getRoleType.mockReturnValue(Roles.GuestTeacher);
+    permissionControllerMock.getRoleId.mockReturnValue('123');
+
+    // Recreate component so constructor picks up mocks
+    const fixture = TestBed.createComponent(DeleteProfileComponent);
+    component = fixture.componentInstance;
+
+    component.deleteProfileForm.controls['email'].setValue('test@example.com');
+    teacherServiceMock.delete.mockReturnValue(of(new HttpResponse({ status: 200 })));
+
+    component.deleteProfile();
+
+    expect(teacherServiceMock.delete).toHaveBeenCalledWith('123');
+    expect(authServiceMock.logout).toHaveBeenCalled();
+  });
+
+  it('should call schoolService.delete and logout for School role', () => {
+    // Set mocks BEFORE creating component
+    permissionControllerMock.getRoleType.mockReturnValue(Roles.School);
+    permissionControllerMock.getRoleId.mockReturnValue('456');
+
+    // Recreate component so constructor picks up mocks
+    const fixture = TestBed.createComponent(DeleteProfileComponent);
+    component = fixture.componentInstance;
+
+    component.deleteProfileForm.controls['email'].setValue('test@example.com');
+    schoolServiceMock.delete.mockReturnValue(of(new HttpResponse({ status: 200 })));
+
+    component.deleteProfile();
+
+    expect(schoolServiceMock.delete).toHaveBeenCalledWith('456');
+    expect(authServiceMock.logout).toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/user/delete-profile/delete-profile.component.ts
+++ b/src/app/pages/user/delete-profile/delete-profile.component.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { PermissionController, Roles } from "../../../services/permission.controller";
+import { HttpResponse } from "@angular/common/http";
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule, ValidationErrors, ValidatorFn,
+  Validators
+} from "@angular/forms";
+import { LittilTeacherService } from "../../../services/littil-teacher/littil-teacher.service";
+import { LittilSchoolService } from "../../../services/littil-school/littil-school.service";
+import { AuthService } from "@auth0/auth0-angular";
+import { CommonModule } from "@angular/common";
+import { ButtonComponent } from "../../../components/button/button.component";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import { FormInputTextComponent } from "../../../components/forms/text-input/form-input-text.component";
+import { FormErrorMessageComponent } from "../../../components/forms/form-error-message/form-error-message.component";
+import { ProfileContainerComponent } from "../../../components/profile-container/profile-container.component";
+
+@Component({
+  selector: 'littil-delete-profile',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ButtonComponent,
+    MatCheckboxModule,
+    ReactiveFormsModule,
+    FormInputTextComponent,
+    FormErrorMessageComponent,
+    ProfileContainerComponent
+  ],
+  templateUrl: './delete-profile.component.html',
+})
+export class DeleteProfileComponent {
+  private readonly roleType: Roles;
+  private readonly roleId: string;
+
+  public deleteProfileForm = new FormGroup({
+    email: new FormControl('', [
+      Validators.required,
+      matchLoggedInEmailValidator(this.permissionController.activeAccount.email)
+    ]),
+  });
+
+  constructor(
+    private permissionController: PermissionController,
+    private littilTeacherService: LittilTeacherService,
+    private littilSchoolService: LittilSchoolService,
+    public auth: AuthService,
+  ) {
+    this.roleType = this.permissionController.getRoleType();
+    this.roleId = this.permissionController.getRoleId();
+  }
+
+  validEmail(): boolean {
+    const control = this.deleteProfileForm.controls['email'];
+    return control.valid && control.value === this.permissionController.activeAccount.email;
+  }
+
+  deleteProfile(): void {
+    const deletionObservable =
+      this.roleType == Roles.GuestTeacher
+        ? this.littilTeacherService.delete(this.roleId)
+        : this.littilSchoolService.delete(this.roleId);
+
+    deletionObservable.subscribe((response: HttpResponse<any> | null) => {
+      if (response?.ok) {
+        this.auth.logout();
+      }
+    });
+  }
+}
+
+function matchLoggedInEmailValidator(loggedInEmail: string | undefined): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value) return null; // laat required dit afhandelen
+    return control.value === loggedInEmail ? null : { emailMismatch: true };
+  };
+}

--- a/src/app/pages/user/delete-profile/delete-profile.component.ts
+++ b/src/app/pages/user/delete-profile/delete-profile.component.ts
@@ -44,9 +44,9 @@ export class DeleteProfileComponent {
   });
 
   constructor(
-    private permissionController: PermissionController,
-    private littilTeacherService: LittilTeacherService,
-    private littilSchoolService: LittilSchoolService,
+    private readonly permissionController: PermissionController,
+    private readonly littilTeacherService: LittilTeacherService,
+    private readonly littilSchoolService: LittilSchoolService,
     public auth: AuthService,
   ) {
     this.roleType = this.permissionController.getRoleType();

--- a/src/app/pages/user/profile/profile.component.html
+++ b/src/app/pages/user/profile/profile.component.html
@@ -106,47 +106,6 @@
           Wijzigingen annuleren
         </littil-button>
       </div>
-      <littil-button
-        data-test="enable_delete_profile"
-        [inline]="true"
-        color="red"
-        (click)="deleteProfileOpen = !deleteProfileOpen; $event.preventDefault()"
-      >
-        Profiel verwijderen
-      </littil-button>
-    </div>
-  </form>
-  <form
-    data-test="delete_profile"
-    class="border border-red-600 rounded rounded-md p-2 mt-8 text-red-900"
-    *ngIf="deleteProfileOpen"
-    [formGroup]="deleteProfileForm"
-  >
-    <p class="mt-0">
-      Weet u zeker dat u uw profiel wilt verwijderen? Al uw gegevens worden verwijderd. Dit kan niet
-      ongedaan worden gemaakt. Geef hieronder uw e-mailadres in en klik op verwijderen om door te
-      gaan.
-    </p>
-
-    <div class="flex">
-      <littil-form-input-text formControlName="email" placeholder="email@example.com" class="grow">
-        <littil-form-error-message
-          [customErrors]="{ email_missing: 'Vul ter bevestiging uw eigen e-mailadres in' }"
-          controlName="email"
-        ></littil-form-error-message>
-      </littil-form-input-text>
-    </div>
-    <div class="flex justify-between">
-      <littil-button
-        [inline]="true"
-        (click)="deleteProfileOpen = !deleteProfileOpen; $event.preventDefault()"
-        color="yellow"
-      >
-        Verwijderen annuleren
-      </littil-button>
-      <littil-button [inline]="true" color="red" (click)="deleteProfile(); $event.preventDefault()">
-        Profiel definitief verwijderen
-      </littil-button>
     </div>
   </form>
 </littil-profile-container>

--- a/src/app/pages/user/profile/profile.component.ts
+++ b/src/app/pages/user/profile/profile.component.ts
@@ -1,5 +1,4 @@
 import { CommonModule } from '@angular/common';
-import { HttpResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import {
   FormBuilder,
@@ -21,10 +20,7 @@ import {
   SchoolPostResource,
 } from '../../../api/generated';
 import { ButtonComponent } from '../../../components/button/button.component';
-import { ContentContainerComponent } from '../../../components/content-container/content-container.component';
-import { FooterComponent } from '../../../components/footer/footer.component';
 import { FormErrorMessageComponent } from '../../../components/forms/form-error-message/form-error-message.component';
-import { FormInputRadioComponent } from '../../../components/forms/radio-input/form-input-radio.component';
 import { FormInputTextComponent } from '../../../components/forms/text-input/form-input-text.component';
 import { ProfileContainerComponent } from '../../../components/profile-container/profile-container.component';
 import { AvailabilityService } from '../../../services/availability.service';
@@ -40,14 +36,11 @@ import { FormUtil } from '../../../utils/form.util';
   imports: [
     CommonModule,
     ProfileContainerComponent,
-    ContentContainerComponent,
     ButtonComponent,
     MatCheckboxModule,
     ReactiveFormsModule,
     FormInputTextComponent,
-    FormInputRadioComponent,
     FormErrorMessageComponent,
-    FooterComponent,
   ],
 })
 export class ProfileComponent {
@@ -59,11 +52,6 @@ export class ProfileComponent {
   public FormUtil = FormUtil;
   public profileForm!: FormGroup;
   public isSchool = false;
-  public deleteProfileOpen = false;
-
-  public deleteProfileForm = new FormGroup({
-    email: new FormControl('', [Validators.required, Validators.email]),
-  });
 
   constructor(
     private permissionController: PermissionController,
@@ -209,22 +197,4 @@ export class ProfileComponent {
     });
   }
 
-  deleteProfile(): void {
-    const control = this.deleteProfileForm.controls['email'];
-    if (control.value !== this.permissionController.activeAccount.email) {
-      control.markAsTouched();
-      control.setErrors({ email_missing: true });
-      return;
-    }
-    const deletionObservable =
-      this.roleType == Roles.GuestTeacher
-        ? this.littilTeacherService.delete(this.roleId)
-        : this.littilSchoolService.delete(this.roleId);
-
-    deletionObservable.subscribe((response: HttpResponse<any>) => {
-      if (response.ok) {
-        this.auth.logout();
-      }
-    });
-  }
 }

--- a/src/app/pages/user/user.routes.ts
+++ b/src/app/pages/user/user.routes.ts
@@ -27,4 +27,9 @@ export const routes: Routes = [
     loadComponent: () => import('./delete-profile/delete-profile.component').then(m => m.DeleteProfileComponent),
     canActivate: [AuthGuard],
   },
+  {
+    path: 'change-email',
+    loadComponent: () => import('./change-email/change-email.component').then(m => m.ChangeEmailComponent),
+    canActivate: [AuthGuard],
+  },
 ];

--- a/src/app/pages/user/user.routes.ts
+++ b/src/app/pages/user/user.routes.ts
@@ -22,4 +22,9 @@ export const routes: Routes = [
     loadComponent: () => import('./modules/modules.component').then(m => m.ModulesComponent),
     canActivate: [AuthGuard],
   },
+  {
+    path: 'delete',
+    loadComponent: () => import('./delete-profile/delete-profile.component').then(m => m.DeleteProfileComponent),
+    canActivate: [AuthGuard],
+  },
 ];

--- a/src/app/services/littil-school/littil-school.service.ts
+++ b/src/app/services/littil-school/littil-school.service.ts
@@ -8,6 +8,7 @@ import {
   SchoolService
 } from '../../api/generated';
 import { IHasManageableModules } from "../littil-modules/littil-modules-user.interface";
+import { HttpResponse } from "@angular/common/http";
 
 @Injectable({
   providedIn: 'root',
@@ -37,8 +38,8 @@ export class LittilSchoolService implements IHasManageableModules {
     return this.schoolService.apiV1SchoolsPut(school);
   }
 
-  delete(id: string): Observable<any> {
-    return this.schoolService.apiV1SchoolsIdDelete(id);
+  delete(id: string): Observable<HttpResponse<any>> {
+    return this.schoolService.apiV1SchoolsIdDelete(id, 'response');
   }
 
   getModules(id: string): Observable<any> {

--- a/src/app/services/littil-teacher/littil-teacher.service.ts
+++ b/src/app/services/littil-teacher/littil-teacher.service.ts
@@ -9,6 +9,7 @@ import {
   TeacherService,
 } from '../../api/generated';
 import { IHasManageableModules } from "../littil-modules/littil-modules-user.interface";
+import { HttpResponse } from "@angular/common/http";
 
 @Injectable({
   providedIn: 'root',
@@ -34,8 +35,8 @@ export class LittilTeacherService implements IHasManageableModules {
     return this.teacherService.apiV1GuestTeachersPut(teacher);
   }
 
-  delete(id: string): Observable<any> {
-    return this.teacherService.apiV1GuestTeachersIdDelete(id);
+  delete(id: string): Observable<HttpResponse<any>> {
+    return this.teacherService.apiV1GuestTeachersIdDelete(id,'response');
   }
 
   getModules(id: string): Observable<Module[]> {

--- a/src/app/services/littil-user/littil-user.service.spec.ts
+++ b/src/app/services/littil-user/littil-user.service.spec.ts
@@ -26,14 +26,14 @@ describe('LittilUserService', () => {
   describe('getById', () => {
     it('should get user by id', () => {
       spectator.service.getById('123').subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/users/user/123', HttpMethod.GET);
+      spectator.expectOne(baseUrl + '/api/v2/users/123', HttpMethod.GET);
     });
   });
 
   describe('getAll', () => {
     it('should get all users', () => {
       spectator.service.getAll().subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/users/user', HttpMethod.GET);
+      spectator.expectOne(baseUrl + '/api/v2/users', HttpMethod.GET);
     });
   });
 
@@ -44,7 +44,7 @@ describe('LittilUserService', () => {
           emailAddress: 'email@email.nl',
         } as User)
         .subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/users/user', HttpMethod.POST);
+      spectator.expectOne(baseUrl + '/api/v2/users', HttpMethod.POST);
     });
   });
 
@@ -52,7 +52,7 @@ describe('LittilUserService', () => {
     it('should delete user', () => {
       spectator.service.delete('123').subscribe();
       spectator.expectOne(
-        baseUrl + '/api/v1/users/user/123',
+        baseUrl + '/api/v2/users/123',
         HttpMethod.DELETE
       );
     });
@@ -61,7 +61,7 @@ describe('LittilUserService', () => {
   describe('getUserStatistics', () => {
     it('should get the userStatistics', () => {
       spectator.service.getUserStatistics().subscribe();
-      spectator.expectOne(baseUrl + '/api/v1/users/statistics', HttpMethod.GET);
+      spectator.expectOne(baseUrl + '/api/v2/users/statistics', HttpMethod.GET);
     });
   });
 

--- a/src/app/services/littil-user/littil-user.service.ts
+++ b/src/app/services/littil-user/littil-user.service.ts
@@ -1,36 +1,48 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
-  ApiV1UsersUserGet201Response,
+  ApiV1UsersUserGet201Response, ChangeEmailResource, EmailVerficationCodeResource,
   User,
   UsersService,
-  UserStatistics,
-} from '../../api/generated';
+  UserStatistics
+} from "../../api/generated";
+import { HttpResponse } from "@angular/common/http";
 
 @Injectable({
   providedIn: 'root',
 })
 export class LittilUserService {
+
   constructor(private userService: UsersService) {}
 
   getById(id: string): Observable<User> {
-    return this.userService.apiV1UsersUserIdGet(id);
+    return this.userService.apiV2UsersIdGet(id);
   }
 
   getAll(): Observable<User[]> {
-    return this.userService.apiV1UsersUserGet();
+    return this.userService.apiV2UsersGet();
   }
 
   create(user: User): Observable<ApiV1UsersUserGet201Response> {
-    return this.userService.apiV1UsersUserPost(user);
+    return this.userService.apiV2UsersPost(user);
   }
 
   delete(id: string): Observable<any> {
-    return this.userService.apiV1UsersUserIdDelete(id);
+    return this.userService.apiV2UsersIdDelete(id);
   }
 
   getUserStatistics(): Observable<UserStatistics[]> {
-    return this.userService.apiV1UsersStatisticsGet();
+    return this.userService.apiV2UsersStatisticsGet();
+  }
+
+  emailVerificationCode(id: string,
+            emailVerificationCodeResource: EmailVerficationCodeResource): Observable<HttpResponse<any>>  {
+    return this.userService.apiV2UsersIdEmailChangeRequestPost(id,
+      emailVerificationCodeResource,'response');
+  }
+
+  changeEmail(id: string, changeEmailResource: ChangeEmailResource): Observable<HttpResponse<any>> {
+    return this.userService.apiV2UsersIdEmailChangeVerifyPatch(id,changeEmailResource, 'response');
   }
 
 }

--- a/src/app/services/permission.controller.ts
+++ b/src/app/services/permission.controller.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { User } from '@auth0/auth0-angular';
 import { Subject } from 'rxjs';
+import { activeAccountNameSignal } from "../state/active-account-name.signal";
 
 export interface IAuth0Authorizations {
   guest_teachers: any[];
@@ -31,6 +32,7 @@ export class PermissionController {
     this.userId = user['https://littil.org/littil_user_id'];
     this.roles = user['https://littil.org/roles'];
     this.setAuthorizations(user['https://littil.org/authorizations']);
+    activeAccountNameSignal.set(String(user.email ?? 'TODO'));
   }
 
   setAuthorizations(authorizations: IAuth0Authorizations) {

--- a/src/app/state/active-account-name.signal.ts
+++ b/src/app/state/active-account-name.signal.ts
@@ -1,0 +1,4 @@
+import { signal } from '@angular/core';
+
+export const activeAccountNameSignal = signal<string>('');
+


### PR DESCRIPTION
### Update user profile menu 
 - move delete profile to separate menu item
 - changes to prevent window resizing
 - menu option to change email address (with use of a verification code send by mail)

**delete profile**
<img width="1313" height="410" alt="image" src="https://github.com/user-attachments/assets/4263ad06-b7b1-4fec-b491-44f18900c408" />

**change email address flow**

set new email address
<img width="1336" height="392" alt="image" src="https://github.com/user-attachments/assets/e5539eff-2210-4688-a405-fc4d14cdecf8" />

Confirm email change with verification code received by mail
<img width="1312" height="563" alt="image" src="https://github.com/user-attachments/assets/86f01a15-ab51-4108-9740-9879f25d1ad3" />

Happy flow:  confirm email change (wijzig e-mail)
<img width="971" height="267" alt="image" src="https://github.com/user-attachments/assets/fdaf1068-e14c-49f0-b779-7ce3a4be2d46" />


Unhappy flow : Cancel email change (Annuleren)
<img width="827" height="312" alt="image" src="https://github.com/user-attachments/assets/88d51e5e-124f-45db-a967-e35f43692a6c" />

